### PR TITLE
Svg parsing now accepts one line svg and line breaks in the middle of the svg tag without crashing

### DIFF
--- a/src/network-area-diagram-viewer.ts
+++ b/src/network-area-diagram-viewer.ts
@@ -121,7 +121,7 @@ export class NetworkAreaDiagramViewer {
 
     public getDimensionsFromSvg(): DIMENSIONS {
         // Dimensions are set in the main svg tag attributes. We want to parse those data without loading the whole svg in the DOM.
-        const result = this.svgContent.match('<svg(.*)>');
+        const result = this.svgContent.match('<svg[^>]*>');
         if (result === null || result.length === 0) {
             return null;
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
If the svg argument is written on a single line, or if there is a line break in the middle of the svg tag, the component crashes


**What is the new behavior (if this is a feature change)?**
If the svg argument is written on a single line, or if there is a line break in the middle of the svg tag, the component works as intended