### PR TITLE
We now store original SLD dimensions

### DIFF
--- a/src/single-line-diagram-viewer.ts
+++ b/src/single-line-diagram-viewer.ts
@@ -87,6 +87,8 @@ export class SingleLineDiagramViewer {
     svgMetadata: SLDMetadata | null;
     width: number;
     height: number;
+    originalWidth: number;
+    originalHeight: number;
     onNextVoltageCallback: OnNextVoltageCallbackType | null;
     onBreakerCallback: OnBreakerCallbackType | null;
     onFeederCallback: OnFeederCallbackType | null;
@@ -120,6 +122,8 @@ export class SingleLineDiagramViewer {
         this.selectionBackColor = selectionBackColor;
         this.width = 0;
         this.height = 0;
+        this.originalWidth = 0;
+        this.originalHeight = 0;
         this.init(minWidth, minHeight, maxWidth, maxHeight);
         this.arrowSvg = ARROW_SVG;
         this.arrowHoverSvg = ARROW_HOVER_SVG;
@@ -130,8 +134,16 @@ export class SingleLineDiagramViewer {
         this.width = width;
     }
 
+    public setOriginalWidth(originalWidth: number): void {
+        this.originalWidth = originalWidth;
+    }
+
     public setHeight(height: number): void {
         this.height = height;
+    }
+
+    public setOriginalHeight(originalHeight: number): void {
+        this.originalHeight = originalHeight;
     }
 
     public setContainer(container: HTMLElement): void {
@@ -146,8 +158,16 @@ export class SingleLineDiagramViewer {
         return this.width;
     }
 
+    public getOriginalWidth(): number {
+        return this.originalWidth;
+    }
+
     public getHeight(): number {
         return this.height;
+    }
+
+    public getOriginalHeight(): number {
+        return this.originalHeight;
     }
 
     public getContainer(): HTMLElement {
@@ -187,6 +207,9 @@ export class SingleLineDiagramViewer {
 
         // clear the previous svg in div element before replacing
         this.container.innerHTML = '';
+
+        this.setOriginalWidth(dimensions.width);
+        this.setOriginalHeight(dimensions.height);
 
         this.setWidth(
             dimensions.width < minWidth


### PR DESCRIPTION
Signed-off-by: LE SAULNIER Kevin <kevin.lesaulnier@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
We can't get original SLD size from other components


**What is the new behavior (if this is a feature change)?**
We can get original SLD dimensions from other components



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
