### PR TITLE
New function to refresh zoom in order to prevent the app from exceeding min/max zoom

### DIFF
--- a/src/single-line-diagram-viewer.ts
+++ b/src/single-line-diagram-viewer.ts
@@ -175,16 +175,16 @@ export class SingleLineDiagramViewer {
     // this method calculates min/max zooms depending on current sld size, then checks current zoom isn't exceeding any of them
     public refreshZoom(): void {
         // min and max zoom depends on the ratio between client width / height and SVG width / height
-        let ratioX = this.getWidth() / this.getContainer().clientWidth;
-        let ratioY = this.getHeight() / this.getContainer().clientHeight;
-        let ratio = Math.max(ratioX, ratioY);
+        const ratioX = this.getWidth() / this.getContainer().clientWidth;
+        const ratioY = this.getHeight() / this.getContainer().clientHeight;
+        const ratio = Math.max(ratioX, ratioY);
 
-        let minZoom =
+        const minZoom =
             ratio *
             (this.svgType === 'voltage-level'
                 ? MIN_ZOOM_LEVEL_VL
                 : MIN_ZOOM_LEVEL_SUB);
-        let maxZoom = ratio * MAX_ZOOM_LEVEL;
+        const maxZoom = ratio * MAX_ZOOM_LEVEL;
 
         if (this.svgDraw) {
             if (this.svgDraw.zoom() > maxZoom) {

--- a/src/single-line-diagram-viewer.ts
+++ b/src/single-line-diagram-viewer.ts
@@ -38,6 +38,10 @@ const FEEDER_COMPONENT_TYPES = new Set([
     'PHASE_SHIFT_TRANSFORMER',
 ]);
 
+const MAX_ZOOM_LEVEL = 10;
+const MIN_ZOOM_LEVEL_SUB = 0.1;
+const MIN_ZOOM_LEVEL_VL = 0.5;
+
 const ARROW_SVG =
     '<svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg"><path class="arrow" fill-rule="evenodd" clip-rule="evenodd" d="M16 24.0163L17.2358 25.3171L21.9837 20.5691L26.7317 25.3171L28 24.0163L21.9837 18L16 24.0163Z"/></svg>';
 const ARROW_HOVER_SVG =
@@ -168,6 +172,26 @@ export class SingleLineDiagramViewer {
         }
     }
 
+    // this method calculates min/max zooms depending on current sld size, then checks current zoom isn't exceeding any of them
+    public refreshZoom() : void {
+        // min and max zoom depends on the ratio between client width / height and SVG width / height
+        let ratioX = (this.getWidth()) / this.getContainer().clientWidth;
+        let ratioY = (this.getHeight()) / this.getContainer().clientHeight;
+        let ratio =  Math.max(ratioX, ratioY);
+
+        let minZoom = ratio * (this.svgType === 'voltage-level' ? MIN_ZOOM_LEVEL_VL : MIN_ZOOM_LEVEL_SUB);
+        let maxZoom = ratio * MAX_ZOOM_LEVEL;
+
+        if(this.svgDraw){
+            if(this.svgDraw.zoom() > maxZoom){
+                this.svgDraw.zoom(maxZoom);
+            }
+            if(this.svgDraw.zoom() < minZoom){
+                this.svgDraw.zoom(minZoom);
+            }
+        }
+    }
+
     public init(
         minWidth: number,
         minHeight: number,
@@ -209,8 +233,8 @@ export class SingleLineDiagramViewer {
             )
             .panZoom({
                 panning: true,
-                zoomMin: this.svgType === 'voltage-level' ? 0.5 : 0.1,
-                zoomMax: 10,
+                zoomMin: this.svgType === 'voltage-level' ? MIN_ZOOM_LEVEL_VL : MIN_ZOOM_LEVEL_SUB,
+                zoomMax: MAX_ZOOM_LEVEL,
                 zoomFactor: this.svgType === 'voltage-level' ? 0.3 : 0.15,
                 margins: { top: 100, left: 100, right: 100, bottom: 100 },
             });

--- a/src/single-line-diagram-viewer.ts
+++ b/src/single-line-diagram-viewer.ts
@@ -173,20 +173,24 @@ export class SingleLineDiagramViewer {
     }
 
     // this method calculates min/max zooms depending on current sld size, then checks current zoom isn't exceeding any of them
-    public refreshZoom() : void {
+    public refreshZoom(): void {
         // min and max zoom depends on the ratio between client width / height and SVG width / height
-        let ratioX = (this.getWidth()) / this.getContainer().clientWidth;
-        let ratioY = (this.getHeight()) / this.getContainer().clientHeight;
-        let ratio =  Math.max(ratioX, ratioY);
+        let ratioX = this.getWidth() / this.getContainer().clientWidth;
+        let ratioY = this.getHeight() / this.getContainer().clientHeight;
+        let ratio = Math.max(ratioX, ratioY);
 
-        let minZoom = ratio * (this.svgType === 'voltage-level' ? MIN_ZOOM_LEVEL_VL : MIN_ZOOM_LEVEL_SUB);
+        let minZoom =
+            ratio *
+            (this.svgType === 'voltage-level'
+                ? MIN_ZOOM_LEVEL_VL
+                : MIN_ZOOM_LEVEL_SUB);
         let maxZoom = ratio * MAX_ZOOM_LEVEL;
 
-        if(this.svgDraw){
-            if(this.svgDraw.zoom() > maxZoom){
+        if (this.svgDraw) {
+            if (this.svgDraw.zoom() > maxZoom) {
                 this.svgDraw.zoom(maxZoom);
             }
-            if(this.svgDraw.zoom() < minZoom){
+            if (this.svgDraw.zoom() < minZoom) {
                 this.svgDraw.zoom(minZoom);
             }
         }
@@ -233,7 +237,10 @@ export class SingleLineDiagramViewer {
             )
             .panZoom({
                 panning: true,
-                zoomMin: this.svgType === 'voltage-level' ? MIN_ZOOM_LEVEL_VL : MIN_ZOOM_LEVEL_SUB,
+                zoomMin:
+                    this.svgType === 'voltage-level'
+                        ? MIN_ZOOM_LEVEL_VL
+                        : MIN_ZOOM_LEVEL_SUB,
                 zoomMax: MAX_ZOOM_LEVEL,
                 zoomFactor: this.svgType === 'voltage-level' ? 0.3 : 0.15,
                 margins: { top: 100, left: 100, right: 100, bottom: 100 },


### PR DESCRIPTION
Signed-off-by: LE SAULNIER Kevin <kevin.lesaulnier@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature

**What is the new behavior (if this is a feature change)?**
The new function will calculate the min/max zoom allowed depending on the current sld size, then will check if the app is not exceeding it.
If it does, it will zoom in/out up to the corresponding limit
