### PR TITLE
[sld-viewer] Center navigation arrow

### DIFF
--- a/src/single-line-diagram-viewer.ts
+++ b/src/single-line-diagram-viewer.ts
@@ -429,10 +429,11 @@ export class SingleLineDiagramViewer {
                     const xs = transform?.[0]?.match(/\d+/)?.[0];
                     if (xs !== undefined) {
                         const x = parseInt(xs, 10);
+			const fWidth = this.svgMetadata?.components.find((comp) => comp.type === element.componentType)?.size.width || 0;
                         this.createSvgArrow(
                             elementById,
                             element.direction,
-                            x,
+                            x + fWidth / 2,
                             highestY.get(element.vid),
                             lowestY.get(element.vid)
                         );

--- a/src/single-line-diagram-viewer.ts
+++ b/src/single-line-diagram-viewer.ts
@@ -429,7 +429,10 @@ export class SingleLineDiagramViewer {
                     const xs = transform?.[0]?.match(/\d+/)?.[0];
                     if (xs !== undefined) {
                         const x = parseInt(xs, 10);
-			const fWidth = this.svgMetadata?.components.find((comp) => comp.type === element.componentType)?.size.width || 0;
+                        const fWidth =
+                            this.svgMetadata?.components.find(
+                                (comp) => comp.type === element.componentType
+                            )?.size.width || 0;
                         this.createSvgArrow(
                             elementById,
                             element.direction,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
Navigation arrow is not centred in the cell except for lines.
![screenshot](https://github.com/powsybl/powsybl-diagram-viewer/assets/66690739/25e20505-35b1-492c-8189-743c9b120314)
 


**What is the new behavior (if this is a feature change)?**
Navigation arrow centred for two-winding transformers and HVDC.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No