### PR TITLE
create-filters-with-draw-control

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,19 +1,17 @@
 module.exports = {
     root: true,
     parser: '@typescript-eslint/parser',
-    plugins: [
-        '@typescript-eslint',
-    ],
+    plugins: ['@typescript-eslint'],
     extends: [
+        'plugin:react-hooks/recommended',
         'eslint:recommended',
         'plugin:@typescript-eslint/recommended',
-        "plugin:prettier/recommended",
-        'prettier'
+        'plugin:prettier/recommended'
     ],
-    env : {
+    env: {
         "browser": true
     },
     rules: {
-        "prettier/prettier": "warn"
+        "prettier/prettier": "warn",
     },
 };

--- a/README.md
+++ b/README.md
@@ -39,3 +39,11 @@ you need to follow the steps below:
 -   [Login on the command line to the npm registry](https://docs.npmjs.com/logging-in-to-an-npm-enterprise-registry-from-the-command-line): `npm login`
 -   [Publish the package](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages#publishing-scoped-public-packages): `npm publish`
 
+Notes :
+* Check [license-checker-config.json](license-checker-config.json) for license white list and exclusion.
+  If you need to update this list, please inform organization's owners.
+* We need to exclude some packages for now :
+    * `@mapbox/jsonlint-lines-primitives@2.0.2` is a special license
+    * `cartocolor@4.0.2` is Creative Commons but not correctly described in the package
+    * `rw@0.1.4` is BSD-3-Clause but not correctly described in the package
+    

--- a/demo/src/App.jsx
+++ b/demo/src/App.jsx
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { NetworkMap, GeoData } from '../../src/';
 import {
     createTheme,
@@ -78,6 +78,9 @@ function App() {
         };
     }, []);
 
+    const networkMapRef = useRef();
+    const filteredNominalVoltages = [380.0, 225.0, 110.0];
+
     return (
         <div className="App">
             <header className="App-header"></header>
@@ -91,6 +94,7 @@ function App() {
                         }}
                     >
                         <NetworkMap
+                            ref={networkMapRef}
                             mapEquipments={mapEquipments}
                             geoData={geoData}
                             labelsZoomThreshold={LABELS_ZOOM_THRESHOLD}
@@ -124,6 +128,25 @@ function App() {
                             }}
                             mapLibrary={'cartonolabel'}
                             mapTheme={'dark'}
+                            filteredNominalVoltages={filteredNominalVoltages}
+                            onDrawPolygonModeActive={(active) => {
+                                console.log(
+                                    'polygon drawing mode active: ',
+                                    active ? 'active' : 'inactive'
+                                );
+                            }}
+                            onPolygonChanged={() => {
+                                console.log(
+                                    'Selected Substations: ',
+                                    networkMapRef.current.getSelectedSubstations()
+                                        .length
+                                );
+                                console.log(
+                                    'Selected Lines: ',
+                                    networkMapRef.current.getSelectedLines()
+                                        .length
+                                );
+                            }}
                         />
                     </div>
                 </ThemeProvider>

--- a/demo/src/map-viewer/data/smap.json
+++ b/demo/src/map-viewer/data/smap.json
@@ -6,12 +6,12 @@
       {
         "id": "VL1_1",
         "substationId": "SUB1",
-        "nominalVoltage": 225.0
+        "nominalV": 225.0
       },
       {
         "id": "VL1_2",
         "substationId": "SUB1",
-        "nominalVoltage": 110.0
+        "nominalV": 110.0
       }
 
     ]
@@ -23,17 +23,17 @@
       {
         "id": "VL2_1",
         "substationId": "SUB2",
-        "nominalVoltage": 110.0
+        "nominalV": 110.0
       },
       {
         "id": "VL2_2",
         "substationId": "SUB2",
-        "nominalVoltage": 380.0
+        "nominalV": 380.0
       },
       {
         "id": "VL2_3",
         "substationId": "SUB2",
-        "nominalVoltage": 225.0
+        "nominalV": 225.0
       }
     ]
   }

--- a/license-checker-config.json
+++ b/license-checker-config.json
@@ -19,6 +19,7 @@
     ],
     "excludePackages": [
         "@mapbox/jsonlint-lines-primitives@2.0.2",
-        "cartocolor@4.0.2"
+        "cartocolor@4.0.2",
+        "rw@0.1.4"
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,11 @@
             "version": "0.3.5",
             "license": "MPL-2.0",
             "dependencies": {
+                "@mapbox/mapbox-gl-draw": "^1.4.3",
                 "@svgdotjs/svg.js": "^3.2.0",
                 "@svgdotjs/svg.panzoom.js": "^2.1.2",
+                "@turf/boolean-point-in-polygon": "^6.5.0",
+                "@types/mapbox__mapbox-gl-draw": "^1.4.6",
                 "cheap-ruler": "^3.0.2",
                 "deck.gl": "^8.9.35",
                 "geolib": "^3.3.4",
@@ -3892,6 +3895,55 @@
                 "@probe.gl/stats": "^3.5.0"
             }
         },
+        "node_modules/@mapbox/extent": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@mapbox/extent/-/extent-0.4.0.tgz",
+            "integrity": "sha512-MSoKw3qPceGuupn04sdaJrFeLKvcSETVLZCGS8JA9x6zXQL3FWiKaIXYIZEDXd5jpXpWlRxinCZIN49yRy0C9A=="
+        },
+        "node_modules/@mapbox/geojson-area": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
+            "integrity": "sha512-bBqqFn1kIbLBfn7Yq1PzzwVkPYQr9lVUeT8Dhd0NL5n76PBuXzOcuLV7GOSbEB1ia8qWxH4COCvFpziEu/yReA==",
+            "dependencies": {
+                "wgs84": "0.0.0"
+            }
+        },
+        "node_modules/@mapbox/geojson-coords": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/@mapbox/geojson-coords/-/geojson-coords-0.0.2.tgz",
+            "integrity": "sha512-YuVzpseee/P1T5BWyeVVPppyfmuXYHFwZHmybkqaMfu4BWlOf2cmMGKj2Rr92MwfSTOCSUA0PAsVGRG8akY0rg==",
+            "dependencies": {
+                "@mapbox/geojson-normalize": "0.0.1",
+                "geojson-flatten": "^1.0.4"
+            }
+        },
+        "node_modules/@mapbox/geojson-extent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@mapbox/geojson-extent/-/geojson-extent-1.0.1.tgz",
+            "integrity": "sha512-hh8LEO3djT4fqfr8sSC6wKt+p0TMiu+KOLMBUiFOyj+zGq7+IXwQGl0ppCVDkyzCewyd9LoGe9zAvDxXrLfhLw==",
+            "dependencies": {
+                "@mapbox/extent": "0.4.0",
+                "@mapbox/geojson-coords": "0.0.2",
+                "rw": "~0.1.4",
+                "traverse": "~0.6.6"
+            },
+            "bin": {
+                "geojson-extent": "bin/geojson-extent"
+            }
+        },
+        "node_modules/@mapbox/geojson-extent/node_modules/rw": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/rw/-/rw-0.1.4.tgz",
+            "integrity": "sha512-vSj3D96kMcjNyqPcp65wBRIDImGSrUuMxngNNxvw8MQaO+aQ6llzRPH7XcJy5zrpb3wU++045+Uz/IDIM684iw=="
+        },
+        "node_modules/@mapbox/geojson-normalize": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@mapbox/geojson-normalize/-/geojson-normalize-0.0.1.tgz",
+            "integrity": "sha512-82V7YHcle8lhgIGqEWwtXYN5cy0QM/OHq3ypGhQTbvHR57DF0vMHMjjVSQKFfVXBe/yWCBZTyOuzvK7DFFnx5Q==",
+            "bin": {
+                "geojson-normalize": "geojson-normalize"
+            }
+        },
         "node_modules/@mapbox/geojson-rewind": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
@@ -3910,6 +3962,20 @@
             "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/@mapbox/mapbox-gl-draw": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.4.3.tgz",
+            "integrity": "sha512-03qIJgyGmm0IoTZbV/cfODru9jRGogi4LcQ3maxIJDKccq1gY3ofgt2UYPkeU143ElxitZahEythNQv1NpsLhg==",
+            "dependencies": {
+                "@mapbox/geojson-area": "^0.2.2",
+                "@mapbox/geojson-extent": "^1.0.1",
+                "@mapbox/geojson-normalize": "^0.0.1",
+                "@mapbox/point-geometry": "^0.1.0",
+                "hat": "0.0.3",
+                "lodash.isequal": "^4.5.0",
+                "xtend": "^4.0.2"
             }
         },
         "node_modules/@mapbox/mapbox-gl-supported": {
@@ -4925,6 +4991,37 @@
                 "@turf/invariant": "^5.1.5"
             }
         },
+        "node_modules/@turf/boolean-point-in-polygon": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.5.0.tgz",
+            "integrity": "sha512-DtSuVFB26SI+hj0SjrvXowGTUCHlgevPAIsukssW6BG5MlNSBQAo70wpICBNJL6RjukXg8d2eXaAWuD/CqL00A==",
+            "dependencies": {
+                "@turf/helpers": "^6.5.0",
+                "@turf/invariant": "^6.5.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/turf"
+            }
+        },
+        "node_modules/@turf/boolean-point-in-polygon/node_modules/@turf/helpers": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+            "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+            "funding": {
+                "url": "https://opencollective.com/turf"
+            }
+        },
+        "node_modules/@turf/boolean-point-in-polygon/node_modules/@turf/invariant": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+            "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+            "dependencies": {
+                "@turf/helpers": "^6.5.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/turf"
+            }
+        },
         "node_modules/@turf/clone": {
             "version": "5.1.5",
             "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
@@ -5116,6 +5213,15 @@
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true
+        },
+        "node_modules/@types/mapbox__mapbox-gl-draw": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@types/mapbox__mapbox-gl-draw/-/mapbox__mapbox-gl-draw-1.4.6.tgz",
+            "integrity": "sha512-ajnIY/6pMjJhLyz5TUt1ukzs6rl9m/hItzw/b3Z0tQlrFq9vwDNPugLFOuNpLdmgA7emfMxlvxnLKbtE5/vtsw==",
+            "dependencies": {
+                "@types/geojson": "*",
+                "@types/mapbox-gl": "*"
+            }
         },
         "node_modules/@types/mapbox__point-geometry": {
             "version": "0.1.4",
@@ -8263,6 +8369,11 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/geojson-flatten": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/geojson-flatten/-/geojson-flatten-1.1.1.tgz",
+            "integrity": "sha512-k/6BCd0qAt7vdqdM1LkLfAy72EsLDy0laNwX0x2h49vfYCiQkRc4PSra8DNEdJ10EKRpwEvDXMb0dBknTJuWpQ=="
+        },
         "node_modules/geojson-vt": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
@@ -8597,6 +8708,14 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/hat": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz",
+            "integrity": "sha512-zpImx2GoKXy42fVDSEad2BPKuSQdLcqsCYa48K3zHSzM/ugWuYjLDr8IXxpVuL7uCLHw56eaiLxCRthhOzf5ug==",
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/he": {
@@ -11297,8 +11416,7 @@
         "node_modules/lodash.isequal": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-            "dev": true
+            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
         },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
@@ -13588,6 +13706,17 @@
                 "node": ">=12"
             }
         },
+        "node_modules/traverse": {
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
+            "integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/treeify": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
@@ -14307,6 +14436,11 @@
                 "node": ">=12"
             }
         },
+        "node_modules/wgs84": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
+            "integrity": "sha512-ANHlY4Rb5kHw40D0NJ6moaVfOCMrp9Gpd1R/AIQYg2ko4/jzcJ+TVXYYF6kXJqQwITvEZP4yEthjM7U6rYlljQ=="
+        },
         "node_modules/whatwg-encoding": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
@@ -14551,6 +14685,14 @@
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true
+        },
+        "node_modules/xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "engines": {
+                "node": ">=0.4"
+            }
         },
         "node_modules/y18n": {
             "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,11 @@
         "licenses-check": "license-checker --summary --excludePrivatePackages --production --onlyAllow \"$( jq -r .onlyAllow[] license-checker-config.json | tr '\n' ';')\" --excludePackages \"$( jq -r .excludePackages[] license-checker-config.json | tr '\n' ';')\""
     },
     "dependencies": {
+        "@mapbox/mapbox-gl-draw": "^1.4.3",
         "@svgdotjs/svg.js": "^3.2.0",
         "@svgdotjs/svg.panzoom.js": "^2.1.2",
+        "@turf/boolean-point-in-polygon": "^6.5.0",
+        "@types/mapbox__mapbox-gl-draw": "^1.4.6",
         "cheap-ruler": "^3.0.2",
         "deck.gl": "^8.9.35",
         "geolib": "^3.3.4",

--- a/src/components/network-map-viewer/network/draw-control.ts
+++ b/src/components/network-map-viewer/network/draw-control.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import MapboxDraw from '@mapbox/mapbox-gl-draw';
+import { useCallback } from 'react';
+import { useControl } from 'react-map-gl';
+
+import type { ControlPosition } from 'react-map-gl';
+import { EventedListener } from 'mapbox-gl';
+
+let mapDrawerController: MapboxDraw | undefined = undefined;
+
+export function getMapDrawer() {
+    return mapDrawerController;
+}
+
+//source: https://github.com/visgl/react-map-gl/blob/master/examples/draw-polygon/src/
+type DrawControlProps = ConstructorParameters<typeof MapboxDraw>[0] & {
+    position?: ControlPosition;
+    readyToDisplay: boolean;
+    onDrawPolygonModeActive: (polygoneDrawing: boolean) => void;
+    onUpdate: EventedListener;
+    onDelete: EventedListener;
+};
+
+export default function DrawControl(props: DrawControlProps) {
+    const { onDrawPolygonModeActive } = props;
+    const onModeChange = useCallback(
+        (e: { mode: string }) => {
+            if (e.mode === 'draw_polygon') {
+                onDrawPolygonModeActive(true);
+            } else {
+                // mode === 'simple_select'
+                onDrawPolygonModeActive(false);
+            }
+        },
+        [onDrawPolygonModeActive]
+    );
+
+    useControl<MapboxDraw>(
+        //onCreate
+        () => {
+            mapDrawerController = new MapboxDraw({ ...props });
+            return mapDrawerController;
+        },
+        //on add
+        ({ map }) => {
+            map.on('draw.create', props.onUpdate);
+            map.on('draw.update', props.onUpdate);
+            map.on('draw.delete', props.onDelete);
+            map.on('draw.modechange', onModeChange);
+        },
+        //onRemove
+        ({ map }) => {
+            map.off('draw.create', props.onUpdate);
+            map.off('draw.update', props.onUpdate);
+            map.off('draw.delete', props.onDelete);
+            map.off('draw.modechange', onModeChange);
+        },
+        {
+            position: props.position,
+        }
+    );
+
+    return null;
+}
+
+DrawControl.defaultProps = {
+    onUpdate: () => {},
+    onDelete: () => {},
+};

--- a/src/components/network-map-viewer/network/network-map.jsx
+++ b/src/components/network-map-viewer/network/network-map.jsx
@@ -821,19 +821,13 @@ function getSelectedLinesInPolygon(
             if (linePos.length < 2) {
                 return false;
             }
-            if (lineFullPath) {
-                return linePos.some((pos) =>
-                    booleanPointInPolygon(pos, polygonCoordinates)
-                );
-            } else {
-                const linesExtremity = [
-                    linePos[0],
-                    linePos[linePos.length - 1],
-                ];
-                return linesExtremity.some((pos) =>
-                    booleanPointInPolygon(pos, polygonCoordinates)
-                );
-            }
+            const displayedPath = lineFullPath
+                ? linePos
+                : [linePos[0], linePos[linePos.length - 1]];
+
+            return displayedPath.some((pos) =>
+                booleanPointInPolygon(pos, polygonCoordinates)
+            );
         } catch (error) {
             console.error(error);
             return false;

--- a/src/components/network-map-viewer/network/network-map.jsx
+++ b/src/components/network-map-viewer/network/network-map.jsx
@@ -558,7 +558,8 @@ const NetworkMap = forwardRef((props, ref) => {
             props.mapEquipments,
             mapEquipmentsLines,
             props.geoData,
-            polygonCoordinates
+            polygonCoordinates,
+            props.fullPath
         );
         return selectedLines.filter((line) => {
             return props.filteredNominalVoltages.some((nv) => {
@@ -580,6 +581,7 @@ const NetworkMap = forwardRef((props, ref) => {
         mapEquipmentsLines,
         props.geoData,
         props.filteredNominalVoltages,
+        props.fullPath,
     ]);
 
     const getSelectedSubstations = useCallback(() => {
@@ -807,7 +809,8 @@ function getSelectedLinesInPolygon(
     network,
     lines,
     geoData,
-    polygonCoordinates
+    polygonCoordinates,
+    lineFullPath
 ) {
     return lines.filter((line) => {
         try {
@@ -818,12 +821,19 @@ function getSelectedLinesInPolygon(
             if (linePos.length < 2) {
                 return false;
             }
-            //TODO : in the future, we could check if the line is fully in the polygon ( instead of just one point)
-            // we need to have a boolean that checks if detailed line is displayed
-            const linesExtremity = [linePos[0], linePos[linePos.length - 1]];
-            return linesExtremity.some((pos) =>
-                booleanPointInPolygon(pos, polygonCoordinates)
-            ); // at least one point in polygon then OK
+            if (lineFullPath) {
+                return linePos.some((pos) =>
+                    booleanPointInPolygon(pos, polygonCoordinates)
+                );
+            } else {
+                const linesExtremity = [
+                    linePos[0],
+                    linePos[linePos.length - 1],
+                ];
+                return linesExtremity.some((pos) =>
+                    booleanPointInPolygon(pos, polygonCoordinates)
+                );
+            }
         } catch (error) {
             console.error(error);
             return false;

--- a/src/components/network-map-viewer/network/network-map.jsx
+++ b/src/components/network-map-viewer/network/network-map.jsx
@@ -815,8 +815,13 @@ function getSelectedLinesInPolygon(
             if (!linePos) {
                 return false;
             }
-
-            return linePos.some((pos) =>
+            if (linePos.length < 2) {
+                return false;
+            }
+            //TODO : in the future, we could check if the line is fully in the polygon ( instead of just one point)
+            // we need to have a boolean that checks if detailed line is displayed
+            const linesExtremity = [linePos[0], linePos[linePos.length - 1]];
+            return linesExtremity.some((pos) =>
                 booleanPointInPolygon(pos, polygonCoordinates)
             ); // at least one point in polygon then OK
         } catch (error) {

--- a/src/components/network-map-viewer/network/network-map.jsx
+++ b/src/components/network-map-viewer/network/network-map.jsx
@@ -581,7 +581,7 @@ const NetworkMap = forwardRef((props, ref) => {
         mapEquipmentsLines,
         props.geoData,
         props.filteredNominalVoltages,
-        props.fullPath,
+        lineFullPath,
     ]);
 
     const getSelectedSubstations = useCallback(() => {
@@ -821,13 +821,9 @@ function getSelectedLinesInPolygon(
             if (linePos.length < 2) {
                 return false;
             }
-            console.log('debug', 'lineFullPath', lineFullPath);
-            console.log('debug', 'linePos', linePos);
             const displayedPath = lineFullPath
                 ? linePos
                 : [linePos[0], linePos[linePos.length - 1]];
-            console.log('debug', 'displayedPath', displayedPath);
-
             return displayedPath.some((pos) =>
                 booleanPointInPolygon(pos, polygonCoordinates)
             );

--- a/src/components/network-map-viewer/network/network-map.jsx
+++ b/src/components/network-map-viewer/network/network-map.jsx
@@ -109,7 +109,7 @@ const NetworkMap = forwardRef((props, ref) => {
     const [isPolygonDrawingStarted, setPolygonDrawingStarted] = useState(false);
     //NOTE these constants are moved to the component's parameters list
     //const currentNode = useSelector((state) => state.currentTreeNode);
-    const { onPolygonChanged, centerOnSubstation } = props;
+    const { onPolygonChanged, centerOnSubstation, lineFullPath } = props;
 
     const { getNameOrId } = useNameOrId(props.useName);
 
@@ -559,7 +559,7 @@ const NetworkMap = forwardRef((props, ref) => {
             mapEquipmentsLines,
             props.geoData,
             polygonCoordinates,
-            props.fullPath
+            lineFullPath
         );
         return selectedLines.filter((line) => {
             return props.filteredNominalVoltages.some((nv) => {
@@ -821,9 +821,12 @@ function getSelectedLinesInPolygon(
             if (linePos.length < 2) {
                 return false;
             }
+            console.log('debug', 'lineFullPath', lineFullPath);
+            console.log('debug', 'linePos', linePos);
             const displayedPath = lineFullPath
                 ? linePos
                 : [linePos[0], linePos[linePos.length - 1]];
+            console.log('debug', 'displayedPath', displayedPath);
 
             return displayedPath.some((pos) =>
                 booleanPointInPolygon(pos, polygonCoordinates)


### PR DESCRIPTION
New dependencies:
https://docs.mapbox.com/mapbox-gl-js/example/mapbox-gl-draw/
http://turfjs.org/

**informations for the reviewer:**
Mapbox GL JS itself doesn't have a built-in API specifically for detecting features within an area. However, you can achieve this functionality in a couple of ways:

-  using screen coordinates in pixels: [link](https://docs.mapbox.com/android/maps/api/10.0.0-rc.1/-mapbox%20-maps%20-android/com.mapbox.maps/-mapbox-map/query-rendered-features.html). but this solution is not usable in our case.
- Leveraging [Turf.js](http://turfjs.org/): Turf.js is a JavaScript library for geospatial analysis. It offers various functions for working with geographical data. we use pointsWithinPolygon function from Turf.js to identify features  that lie within a defined polygon.

**Turf.js: More suited for pre-processing data or performing more complex spatial analysis. It offers a wider range of geospatial functions.**


MapBox gl draw demo itself use truf.js  :  https://docs.mapbox.com/mapbox-gl-js/example/mapbox-gl-draw/


**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No




