### PR TITLE
ESlint not block Vite build when in development mode

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,11 +5,12 @@ import dts from 'vite-plugin-dts';
 import react from '@vitejs/plugin-react';
 import { externalizeDeps } from 'vite-plugin-externalize-deps';
 
-export default defineConfig({
+export default defineConfig((config) => ({
     plugins: [
         react(),
         eslint({
-            failOnWarning: true,
+            failOnWarning: config.mode !== 'development',
+            lintOnStart: true,
         }),
         dts({
             include: ['src'],
@@ -69,4 +70,4 @@ export default defineConfig({
             },
         },
     },
-});
+}));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] ~Tests for the changes have been added (for bug fixes / features)~
- [ ] ~Docs have been added / updated (for bug fixes / features)~


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fix build blocked when developing with `npm start` command.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When a warning is throw by ESLint (like Prettier syntax), it will block build and hot-reload.


**What is the new behavior (if this is a feature change)?**
ESLint warnings will not be blocking in `development` mode only.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] ~The *Breaking Change* or *Deprecated* label has been added~
- [ ] ~The migration steps are described in the following section~

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
None.


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
cherry pick https://github.com/gridsuite/gridstudy-app/pull/1995
