### PR TITLE
Fix console warning oneOf

### DIFF
--- a/src/components/network-map-viewer/network/network-map.jsx
+++ b/src/components/network-map-viewer/network/network-map.jsx
@@ -744,8 +744,8 @@ NetworkMap.propTypes = {
     geoData: PropTypes.instanceOf(GeoData),
     mapBoxToken: PropTypes.string,
     mapEquipments: PropTypes.instanceOf(MapEquipments),
-    mapLibrary: PropTypes.oneOf(CARTO, CARTO_NOLABEL, MAPBOX),
-    mapTheme: PropTypes.oneOf(LIGHT, DARK),
+    mapLibrary: PropTypes.oneOf([CARTO, CARTO_NOLABEL, MAPBOX]),
+    mapTheme: PropTypes.oneOf([LIGHT, DARK]),
 
     areFlowsValid: PropTypes.bool,
     arrowsZoomThreshold: PropTypes.number,


### PR DESCRIPTION
Warning: Invalid arguments supplied to oneOf, expected an array, got 3 arguments. A common mistake is to write oneOf(x, y, z) instead of oneOf([x, y, z]).
Warning: Invalid arguments supplied to oneOf, expected an array, got 2 arguments. A common mistake is to write oneOf(x, y, z) instead of oneOf([x, y, z]).

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
