### PR TITLE
Move voltage level nodes with multiple buses in network area diagram

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -24,6 +24,9 @@
       <div id="svg-container-nad"></div>
       <div id="svg-container-nad-pst-hvdc"></div>
       <div class="break"></div>
+      <div id="svg-container-nad-multibus-vlnodes"></div>
+      <div id="svg-container-nad-multibus-vlnodes14"></div>
+      <div class="break"></div>
       <div id="svg-container-sld"></div>
       <div id="svg-container-sld-with-callbacks"></div>
       <div class="break"></div>

--- a/demo/src/diagram-viewers/add-diagrams.js
+++ b/demo/src/diagram-viewers/add-diagrams.js
@@ -7,6 +7,8 @@
 
 import NadSvgExample from './data/nad-eurostag-tutorial-example1.svg';
 import NadSvgPstHvdcExample from './data/nad-four-substations.svg';
+import NadSvgMultibusVLNodesExample from './data/nad-ieee9-zeroimpedance-cdf.svg';
+import NadSvgMultibusVLNodes14Example from './data/nad-ieee14cdf-solved.svg';
 import SldSvgExample from './data/sld-example.svg';
 import SldSvgExampleMeta from './data/sld-example-meta.json';
 import SldSvgSubExample from './data/sld-sub-example.svg';
@@ -48,6 +50,42 @@ export const addNadToDemo = () => {
 
             document
                 .getElementById('svg-container-nad-pst-hvdc')
+                .getElementsByTagName('svg')[0]
+                .setAttribute('style', 'border:2px; border-style:solid;');
+        });
+
+    fetch(NadSvgMultibusVLNodesExample)
+        .then((response) => response.text())
+        .then((svgContent) => {
+            new NetworkAreaDiagramViewer(
+                document.getElementById('svg-container-nad-multibus-vlnodes'),
+                svgContent,
+                500,
+                600,
+                1000,
+                1200
+            );
+
+            document
+                .getElementById('svg-container-nad-multibus-vlnodes')
+                .getElementsByTagName('svg')[0]
+                .setAttribute('style', 'border:2px; border-style:solid;');
+        });
+
+    fetch(NadSvgMultibusVLNodes14Example)
+        .then((response) => response.text())
+        .then((svgContent) => {
+            new NetworkAreaDiagramViewer(
+                document.getElementById('svg-container-nad-multibus-vlnodes14'),
+                svgContent,
+                500,
+                600,
+                1000,
+                1200
+            );
+
+            document
+                .getElementById('svg-container-nad-multibus-vlnodes14')
                 .getElementsByTagName('svg')[0]
                 .setAttribute('style', 'border:2px; border-style:solid;');
         });

--- a/demo/src/diagram-viewers/data/nad-eurostag-tutorial-example1.svg
+++ b/demo/src/diagram-viewers/data/nad-eurostag-tutorial-example1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="-387.85 -130.23 1488.27 698.87" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="-652.59 -489.01 1383.49 747.62" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
@@ -114,161 +114,161 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode svgId="1" equipmentId="VLGEN_0"/>
-                <nad:busNode svgId="3" equipmentId="VLHV1_0"/>
-                <nad:busNode svgId="5" equipmentId="VLHV2_0"/>
-                <nad:busNode svgId="7" equipmentId="VLLOAD_0"/>
+                <nad:busNode svgId="1" equipmentId="VLGEN_0" nbNeighbours="0" index="0" vlNode="0"/>
+                <nad:busNode svgId="3" equipmentId="VLHV1_0" nbNeighbours="0" index="0" vlNode="2"/>
+                <nad:busNode svgId="5" equipmentId="VLHV2_0" nbNeighbours="0" index="0" vlNode="4"/>
+                <nad:busNode svgId="7" equipmentId="VLLOAD_0" nbNeighbours="0" index="0" vlNode="6"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node svgId="0" equipmentId="VLGEN" x="-187.85" y="84.77"/>
-                <nad:node svgId="2" equipmentId="VLHV1" x="88.29" y="331.25"/>
-                <nad:node svgId="4" equipmentId="VLHV2" x="473.27" y="368.64"/>
-                <nad:node svgId="6" equipmentId="VLLOAD" x="800.43" y="195.36"/>
+                <nad:node svgId="0" equipmentId="VLGEN" x="-452.59" y="-274.01"/>
+                <nad:node svgId="2" equipmentId="VLHV1" x="-245.26" y="34.30"/>
+                <nad:node svgId="4" equipmentId="VLHV2" x="140.33" y="58.61"/>
+                <nad:node svgId="6" equipmentId="VLLOAD" x="430.90" y="-174.05"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge svgId="8" equipmentId="NGEN_NHV1" node1="0" node2="2"/>
-                <nad:edge svgId="9" equipmentId="NHV1_NHV2_1" node1="2" node2="4"/>
-                <nad:edge svgId="10" equipmentId="NHV1_NHV2_2" node1="2" node2="4"/>
-                <nad:edge svgId="11" equipmentId="NHV2_NLOAD" node1="4" node2="6"/>
+                <nad:edge svgId="8" equipmentId="NGEN_NHV1" node1="0" node2="2" busNode1="1" busNode2="3"/>
+                <nad:edge svgId="9" equipmentId="NHV1_NHV2_1" node1="2" node2="4" busNode1="3" busNode2="5"/>
+                <nad:edge svgId="10" equipmentId="NHV1_NHV2_2" node1="2" node2="4" busNode1="3" busNode2="5"/>
+                <nad:edge svgId="11" equipmentId="NHV2_NLOAD" node1="4" node2="6" busNode1="5" busNode2="7"/>
             </nad:edges>
         </nad:nad>
     </metadata>
     <g class="nad-vl-nodes">
-        <g transform="translate(-187.85,84.77)" id="0">
+        <g transform="translate(-452.59,-274.01)" id="0">
             <circle r="27.50" id="1" class="nad-vl0to30-0 nad-busnode"/>
         </g>
-        <g transform="translate(88.29,331.25)" id="2">
+        <g transform="translate(-245.26,34.30)" id="2">
             <circle r="27.50" id="3" class="nad-vl300to500-0 nad-busnode"/>
         </g>
-        <g transform="translate(473.27,368.64)" id="4">
+        <g transform="translate(140.33,58.61)" id="4">
             <circle r="27.50" id="5" class="nad-vl300to500-0 nad-busnode"/>
         </g>
-        <g transform="translate(800.43,195.36)" id="6">
+        <g transform="translate(430.90,-174.05)" id="6">
             <circle r="27.50" id="7" class="nad-vl120to180-0 nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="8">
             <g id="8.1" class="nad-vl0to30-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-167.33,103.08 -72.16,188.03"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(-143.09,124.72)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-437.24,-251.19 -365.67,-144.75"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-419.11,-224.22)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(131.75)">
+                        <g transform="rotate(146.08)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(41.75)" x="19.00">607</text>
+                        <text transform="rotate(56.08)" x="19.00">607</text>
                     </g>
                 </g>
             </g>
             <g id="8.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="67.77,312.94 -27.40,227.99"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(43.52,291.30)">
-                    <g class="nad-active nad-state-in">
-                        <g transform="rotate(-48.25)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-260.61,11.48 -332.19,-94.96"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-278.75,-15.49)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-33.92)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-318.25)" x="-19.00" style="text-anchor:end">-606</text>
+                        <text transform="rotate(-303.92)" x="-19.00" style="text-anchor:end">-606</text>
                     </g>
                 </g>
             </g>
             <g class="nad-glued-center">
-                <circle class="nad-vl0to30-line nad-winding" cx="-57.24" cy="201.35" r="20.00"/>
-                <circle class="nad-vl300to500-line nad-winding" cx="-42.32" cy="214.67" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="-354.51" cy="-128.15" r="20.00"/>
+                <circle class="nad-vl300to500-line nad-winding" cx="-343.35" cy="-111.56" r="20.00"/>
             </g>
         </g>
         <g id="9">
             <g id="9.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="110.66,347.24 153.38,377.76 276.91,389.76"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(183.24,380.66)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-222.36,49.52 -178.64,78.58 -54.98,86.38"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-148.70,80.47)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(95.55)">
+                        <g transform="rotate(93.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(5.55)" x="19.00">302</text>
+                        <text transform="rotate(3.61)" x="19.00">302</text>
                     </g>
                 </g>
             </g>
             <g id="9.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="448.24,380.02 400.45,401.76 276.91,389.76"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(370.59,398.86)">
-                    <g class="nad-active nad-state-in">
-                        <g transform="rotate(-84.45)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="115.70,70.84 68.67,94.17 -54.98,86.38"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(38.73,92.28)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-86.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-354.45)" x="-19.00" style="text-anchor:end">-300</text>
+                        <text transform="rotate(-356.39)" x="-19.00" style="text-anchor:end">-300</text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="10">
             <g id="10.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="113.32,319.87 161.11,298.14 284.64,310.13"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(190.97,301.04)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-220.63,22.07 -173.60,-1.26 -49.95,6.53"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-143.66,0.62)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(95.55)">
+                        <g transform="rotate(93.61)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(5.55)" x="19.00">302</text>
+                        <text transform="rotate(3.61)" x="19.00">302</text>
                     </g>
                 </g>
             </g>
             <g id="10.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="450.90,352.65 408.18,322.13 284.64,310.13"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(378.32,319.23)">
-                    <g class="nad-active nad-state-in">
-                        <g transform="rotate(-84.45)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="117.43,43.39 73.71,14.33 -49.95,6.53"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(43.77,12.44)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-86.39)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-354.45)" x="-19.00" style="text-anchor:end">-300</text>
+                        <text transform="rotate(-356.39)" x="-19.00" style="text-anchor:end">-300</text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="11">
             <g id="11.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="497.57,355.77 610.34,296.04"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(526.29,340.56)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="161.80,41.42 262.20,-38.97"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(187.17,21.11)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(62.09)">
+                        <g transform="rotate(51.32)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-27.91)" x="19.00">601</text>
+                        <text transform="rotate(-38.68)" x="19.00">601</text>
                     </g>
                 </g>
             </g>
             <g id="11.2" class="nad-vl120to180-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="776.12,208.23 663.36,267.96"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(747.40,223.45)">
-                    <g class="nad-active nad-state-in">
-                        <g transform="rotate(-117.91)">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="409.44,-156.86 309.04,-76.47"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(384.07,-136.55)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-128.68)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-27.91)" x="-19.00" style="text-anchor:end">-600</text>
+                        <text transform="rotate(-38.68)" x="-19.00" style="text-anchor:end">-600</text>
                     </g>
                 </g>
             </g>
             <g class="nad-glued-center">
-                <circle class="nad-vl300to500-line nad-winding" cx="628.01" cy="286.68" r="20.00"/>
-                <circle class="nad-vl120to180-line nad-winding" cx="645.69" cy="277.32" r="20.00"/>
+                <circle class="nad-vl300to500-line nad-winding" cx="277.81" cy="-51.47" r="20.00"/>
+                <circle class="nad-vl120to180-line nad-winding" cx="293.43" cy="-63.97" r="20.00"/>
             </g>
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0-textedge" points="-158.18,80.32 -87.85,69.77"/>
-        <polyline id="2-textedge" points="117.95,326.80 188.29,316.25"/>
-        <polyline id="4-textedge" points="502.94,364.19 573.27,353.64"/>
-        <polyline id="6-textedge" points="830.09,190.91 900.43,180.36"/>
+        <polyline id="0-textedge" points="-422.92,-278.46 -352.59,-289.01"/>
+        <polyline id="2-textedge" points="-215.60,29.85 -145.26,19.30"/>
+        <polyline id="4-textedge" points="170.00,54.16 240.33,43.61"/>
+        <polyline id="6-textedge" points="460.57,-178.50 530.90,-189.05"/>
     </g>
     <g class="nad-text-nodes">
-        <foreignObject id="0-textnode" y="44.77" x="-87.85" height="1" width="1">
+        <foreignObject id="0-textnode" y="-314.01" x="-352.59" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>VLGEN</div>
                 <table>
@@ -281,7 +281,7 @@
                 </table>
             </div>
         </foreignObject>
-        <foreignObject id="2-textnode" y="291.25" x="188.29" height="1" width="1">
+        <foreignObject id="2-textnode" y="-5.70" x="-145.26" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>VLHV1</div>
                 <table>
@@ -294,7 +294,7 @@
                 </table>
             </div>
         </foreignObject>
-        <foreignObject id="4-textnode" y="328.64" x="573.27" height="1" width="1">
+        <foreignObject id="4-textnode" y="18.61" x="240.33" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>VLHV2</div>
                 <table>
@@ -307,7 +307,7 @@
                 </table>
             </div>
         </foreignObject>
-        <foreignObject id="6-textnode" y="155.36" x="900.43" height="1" width="1">
+        <foreignObject id="6-textnode" y="-214.05" x="530.90" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>VLLOAD</div>
                 <table>

--- a/demo/src/diagram-viewers/data/nad-four-substations.svg
+++ b/demo/src/diagram-viewers/data/nad-four-substations.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="-84.40 -369.74 1266.03 1219.65" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="-420.40 -730.14 1217.75 1232.45" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 3; stroke-dasharray: 6,7}
 .nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
-.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
-.nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
+.nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 40}
 .nad-branch-edges .nad-tie-line-edge .nad-edge-path {stroke-width: 7}
 .nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
@@ -19,81 +19,16 @@
 .nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
 .nad-text-nodes foreignObject {overflow: visible; color: black}
 .nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
-.nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
 .nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
 .nad-edge-infos .nad-state-in text {fill: #b71c1c}
 .nad-edge-infos .nad-state-out text {fill: #2e7d32}
-.nad-disconnected {--nad-vl-color: #808080}
-.nad-vl0to30-line {--nad-vl-color: #afb42b}
-.nad-vl0to30-0 {--nad-vl-color: #827717}
-.nad-vl0to30-1 {--nad-vl-color: #d4e157}
-.nad-vl0to30-2 {--nad-vl-color: #e6ee9c}
-.nad-vl0to30-3 {--nad-vl-color: #c0ca33}
-.nad-vl0to30-4 {--nad-vl-color: #f0fc83}
-.nad-vl0to30-5 {--nad-vl-color: #9e9d24}
-.nad-vl0to30-6 {--nad-vl-color: #cddc39}
-.nad-vl0to30-7 {--nad-vl-color: #dce775}
-.nad-vl0to30-8 {--nad-vl-color: #ddfc88}
-.nad-vl30to50-line {--nad-vl-color: #ef9a9a}
-.nad-vl30to50-0 {--nad-vl-color: #c2185b}
-.nad-vl30to50-1 {--nad-vl-color: #f06292}
-.nad-vl30to50-2 {--nad-vl-color: #d81b60}
-.nad-vl30to50-3 {--nad-vl-color: #ec407a}
-.nad-vl30to50-4 {--nad-vl-color: #880e4f}
-.nad-vl30to50-5 {--nad-vl-color: #ad1457}
-.nad-vl30to50-6 {--nad-vl-color: #e91e63}
-.nad-vl30to50-7 {--nad-vl-color: #f48fb1}
-.nad-vl30to50-8 {--nad-vl-color: #f8bbd0}
-.nad-vl50to70-line {--nad-vl-color: #9c27b0}
-.nad-vl50to70-0 {--nad-vl-color: #7b1fa2}
-.nad-vl50to70-1 {--nad-vl-color: #ba68c8}
-.nad-vl50to70-2 {--nad-vl-color: #512da8}
-.nad-vl50to70-3 {--nad-vl-color: #ab47bc}
-.nad-vl50to70-4 {--nad-vl-color: #e1bee7}
-.nad-vl50to70-5 {--nad-vl-color: #6a1b9a}
-.nad-vl50to70-6 {--nad-vl-color: #4a148c}
-.nad-vl50to70-7 {--nad-vl-color: #ce93d8}
-.nad-vl50to70-8 {--nad-vl-color: #9575cd}
-.nad-vl70to120-line {--nad-vl-color: #e65100}
-.nad-vl70to120-0 {--nad-vl-color: #fb8c00}
-.nad-vl70to120-1 {--nad-vl-color: #ffb74d}
-.nad-vl70to120-2 {--nad-vl-color: #f57c00}
-.nad-vl70to120-3 {--nad-vl-color: #ffa726}
-.nad-vl70to120-4 {--nad-vl-color: #ffe0b2}
-.nad-vl70to120-5 {--nad-vl-color: #ef6c00}
-.nad-vl70to120-6 {--nad-vl-color: #ff9800}
-.nad-vl70to120-7 {--nad-vl-color: #ffcc80}
-.nad-vl70to120-8 {--nad-vl-color: #fff3e0}
-.nad-vl120to180-line {--nad-vl-color: #00ACC1}
-.nad-vl120to180-0 {--nad-vl-color: #4fc3f7}
-.nad-vl120to180-1 {--nad-vl-color: #01579b}
-.nad-vl120to180-2 {--nad-vl-color: #b3e5fc}
-.nad-vl120to180-3 {--nad-vl-color: #039be5}
-.nad-vl120to180-4 {--nad-vl-color: #81d4fa}
-.nad-vl120to180-5 {--nad-vl-color: #0288d1}
-.nad-vl120to180-6 {--nad-vl-color: #29b6f6}
-.nad-vl120to180-7 {--nad-vl-color: #0277bd}
-.nad-vl120to180-8 {--nad-vl-color: #03a9f4}
-.nad-vl180to300-line {--nad-vl-color: #2e7d32}
-.nad-vl180to300-0 {--nad-vl-color: #81c784}
-.nad-vl180to300-1 {--nad-vl-color: #558b2f}
-.nad-vl180to300-2 {--nad-vl-color: #c8e6c9}
-.nad-vl180to300-3 {--nad-vl-color: #43a047}
-.nad-vl180to300-4 {--nad-vl-color: #a5d6a7}
-.nad-vl180to300-5 {--nad-vl-color: #388e3c}
-.nad-vl180to300-6 {--nad-vl-color: #66bb6a}
-.nad-vl180to300-7 {--nad-vl-color: #1b5e20}
-.nad-vl180to300-8 {--nad-vl-color: #4caf50}
-.nad-vl300to500-line {--nad-vl-color: #d32f2f}
-.nad-vl300to500-0 {--nad-vl-color: #ef5350}
-.nad-vl300to500-1 {--nad-vl-color: #ef9a9a}
-.nad-vl300to500-2 {--nad-vl-color: #b71c1c}
-.nad-vl300to500-3 {--nad-vl-color: #e57373}
-.nad-vl300to500-4 {--nad-vl-color: #e53935}
-.nad-vl300to500-5 {--nad-vl-color: #ff8a80}
-.nad-vl300to500-6 {--nad-vl-color: #f44336}
-.nad-vl300to500-7 {--nad-vl-color: #ffcdd2}
-.nad-vl300to500-8 {--nad-vl-color: #c62828}
+.nad-vl0to30 {--nad-vl-color: #AFB42B}
+.nad-vl30to50 {--nad-vl-color: #EF9A9A}
+.nad-vl50to70 {--nad-vl-color: #9C27B0}
+.nad-vl70to120 {--nad-vl-color: #E65100}
+.nad-vl120to180 {--nad-vl-color: #00ACC1}
+.nad-vl180to300 {--nad-vl-color: #2E7D32}
+.nad-vl300to500 {--nad-vl-color: #D32F2F}
 .nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
@@ -114,255 +49,265 @@
     <metadata>
         <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
             <nad:busNodes>
-                <nad:busNode svgId="1" equipmentId="S1VL1_0"/>
-                <nad:busNode svgId="3" equipmentId="S1VL2_0"/>
-                <nad:busNode svgId="5" equipmentId="S2VL1_0"/>
-                <nad:busNode svgId="7" equipmentId="S3VL1_0"/>
-                <nad:busNode svgId="9" equipmentId="S4VL1_0"/>
+                <nad:busNode svgId="1" equipmentId="S1VL1_0" nbNeighbours="0" index="0" vlNode="0"/>
+                <nad:busNode svgId="3" equipmentId="S1VL2_0" nbNeighbours="0" index="0" vlNode="2"/>
+                <nad:busNode svgId="5" equipmentId="S2VL1_0" nbNeighbours="0" index="0" vlNode="4"/>
+                <nad:busNode svgId="7" equipmentId="S3VL1_0" nbNeighbours="0" index="0" vlNode="6"/>
+                <nad:busNode svgId="9" equipmentId="S4VL1_0" nbNeighbours="0" index="0" vlNode="8"/>
             </nad:busNodes>
             <nad:nodes>
-                <nad:node svgId="0" equipmentId="S1VL1" x="115.60" y="-154.74"/>
-                <nad:node svgId="2" equipmentId="S1VL2" x="238.57" y="218.27"/>
-                <nad:node svgId="4" equipmentId="S2VL1" x="159.83" y="576.28"/>
-                <nad:node svgId="6" equipmentId="S3VL1" x="518.09" y="501.89"/>
-                <nad:node svgId="8" equipmentId="S4VL1" x="881.63" y="649.91"/>
+                <nad:node svgId="0" equipmentId="S1VL1" x="-220.40" y="-515.14"/>
+                <nad:node svgId="2" equipmentId="S1VL2" x="-152.34" y="-133.80"/>
+                <nad:node svgId="4" equipmentId="S2VL1" x="-162.93" y="231.51"/>
+                <nad:node svgId="6" equipmentId="S3VL1" x="171.13" y="91.69"/>
+                <nad:node svgId="8" equipmentId="S4VL1" x="497.34" y="302.31"/>
             </nad:nodes>
             <nad:edges>
-                <nad:edge svgId="10" equipmentId="TWT" node1="0" node2="2"/>
-                <nad:edge svgId="11" equipmentId="HVDC1" node1="2" node2="4"/>
-                <nad:edge svgId="12" equipmentId="HVDC2" node1="2" node2="6"/>
-                <nad:edge svgId="13" equipmentId="LINE_S2S3" node1="4" node2="6"/>
-                <nad:edge svgId="14" equipmentId="LINE_S3S4" node1="6" node2="8"/>
+                <nad:edge svgId="10" equipmentId="TWT" node1="0" node2="2" busNode1="1" busNode2="3"/>
+                <nad:edge svgId="11" equipmentId="HVDC1" node1="2" node2="4" busNode1="3" busNode2="5"/>
+                <nad:edge svgId="12" equipmentId="HVDC2" node1="2" node2="6" busNode1="3" busNode2="7"/>
+                <nad:edge svgId="13" equipmentId="LINE_S2S3" node1="4" node2="6" busNode1="5" busNode2="7"/>
+                <nad:edge svgId="14" equipmentId="LINE_S3S4" node1="6" node2="8" busNode1="7" busNode2="9"/>
             </nad:edges>
         </nad:nad>
     </metadata>
     <g class="nad-vl-nodes">
-        <g transform="translate(115.60,-154.74)" id="0">
-            <circle r="27.50" id="1" class="nad-vl180to300-0 nad-busnode"/>
+        <g transform="translate(-220.40,-515.14)" id="0" class="nad-vl180to300">
+            <desc>S1VL1</desc>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
-        <g transform="translate(238.57,218.27)" id="2">
-            <circle r="27.50" id="3" class="nad-vl300to500-0 nad-busnode"/>
+        <g transform="translate(-152.34,-133.80)" id="2" class="nad-vl300to500">
+            <desc>S1VL2</desc>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
-        <g transform="translate(159.83,576.28)" id="4">
-            <circle r="27.50" id="5" class="nad-vl300to500-0 nad-busnode"/>
+        <g transform="translate(-162.93,231.51)" id="4" class="nad-vl300to500">
+            <desc>S2VL1</desc>
+            <circle r="27.50" id="5" class="nad-busnode"/>
         </g>
-        <g transform="translate(518.09,501.89)" id="6">
-            <circle r="27.50" id="7" class="nad-vl300to500-0 nad-busnode"/>
+        <g transform="translate(171.13,91.69)" id="6" class="nad-vl300to500">
+            <desc>S3VL1</desc>
+            <circle r="27.50" id="7" class="nad-busnode"/>
         </g>
-        <g transform="translate(881.63,649.91)" id="8">
-            <circle r="27.50" id="9" class="nad-vl300to500-0 nad-busnode"/>
+        <g transform="translate(497.34,302.31)" id="8" class="nad-vl300to500">
+            <desc>S4VL1</desc>
+            <circle r="27.50" id="9" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="10">
-            <g id="10.1" class="nad-vl180to300-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="124.21,-128.62 167.69,3.27"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(134.39,-97.75)">
+            <desc>TWT</desc>
+            <g id="10.1" class="nad-vl180to300">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-215.92,-490.04 -191.64,-354.01"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-210.21,-458.05)">
                     <g class="nad-active nad-state-in">
-                        <g transform="rotate(161.75)">
+                        <g transform="rotate(169.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(71.75)" x="19.00">-80</text>
+                        <text transform="rotate(79.88)" x="19.00">-80</text>
                     </g>
                 </g>
             </g>
-            <g id="10.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="229.96,192.15 186.48,60.26"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(219.78,161.28)">
+            <g id="10.2" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-156.82,-158.90 -181.10,-294.94"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-162.53,-190.90)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-18.25)">
+                        <g transform="rotate(-10.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-288.25)" x="-19.00" style="text-anchor:end">80</text>
+                        <text transform="rotate(-280.12)" x="-19.00" style="text-anchor:end">80</text>
                     </g>
                 </g>
             </g>
             <g class="nad-glued-center">
-                <circle class="nad-vl180to300-line nad-winding" cx="173.95" cy="22.27" r="20.00"/>
-                <circle class="nad-vl300to500-line nad-winding" cx="180.22" cy="41.26" r="20.00"/>
-                <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.31,0.95,-0.95,0.31,196.18,-6.12)" class="nad-pst-arrow"/>
+                <circle class="nad-vl180to300 nad-winding" cx="-188.13" cy="-334.32" r="20.00"/>
+                <circle class="nad-vl300to500 nad-winding" cx="-184.62" cy="-314.63" r="20.00"/>
+                <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(0.18,0.98,-0.98,0.18,-162.11,-359.28)" class="nad-pst-arrow"/>
             </g>
         </g>
         <g id="11" class="nad-hvdc-edge">
-            <g id="11.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="232.66,245.13 199.20,397.27"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(225.68,276.87)">
+            <desc>HVDC1</desc>
+            <g id="11.1" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-153.08,-108.31 -157.64,48.86"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-154.02,-75.83)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-167.60)">
+                        <g transform="rotate(-178.34)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-77.60)" x="-19.00" style="text-anchor:end">10</text>
+                        <text transform="rotate(-88.34)" x="-19.00" style="text-anchor:end">10</text>
                     </g>
                 </g>
             </g>
-            <g id="11.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="165.74,549.42 199.20,397.27"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(172.72,517.68)">
+            <g id="11.2" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-162.19,206.02 -157.64,48.86"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-161.25,173.54)">
                     <g class="nad-active nad-state-in">
-                        <g transform="rotate(12.40)">
+                        <g transform="rotate(1.66)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-77.60)" x="19.00">-10</text>
+                        <text transform="rotate(-88.34)" x="19.00">-10</text>
                     </g>
                 </g>
             </g>
             <g class="nad-glued-center">
-                <polyline points="206.72,363.09 191.68,431.46" class="nad-hvdc"/>
+                <polyline points="-156.62,13.87 -158.65,83.84" class="nad-hvdc"/>
             </g>
         </g>
         <g id="12" class="nad-hvdc-edge">
-            <g id="12.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="257.87,237.85 378.33,360.08"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(280.69,261.00)">
+            <desc>HVDC2</desc>
+            <g id="12.1" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-131.42,-119.22 9.40,-21.06"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-104.76,-100.63)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(135.42)">
+                        <g transform="rotate(124.88)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(45.42)" x="19.00">81</text>
+                        <text transform="rotate(34.88)" x="19.00">81</text>
                     </g>
                 </g>
             </g>
-            <g id="12.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="498.78,482.30 378.33,360.08"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(475.97,459.16)">
+            <g id="12.2" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="150.21,77.11 9.40,-21.06"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(123.55,58.52)">
                     <g class="nad-active nad-state-in">
-                        <g transform="rotate(-44.58)">
+                        <g transform="rotate(-55.12)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-314.58)" x="-19.00" style="text-anchor:end">-79</text>
+                        <text transform="rotate(-325.12)" x="-19.00" style="text-anchor:end">-79</text>
                     </g>
                 </g>
             </g>
             <g class="nad-glued-center">
-                <polyline points="353.76,335.15 402.90,385.01" class="nad-hvdc"/>
+                <polyline points="-19.32,-41.07 38.11,-1.04" class="nad-hvdc"/>
             </g>
         </g>
         <g id="13">
-            <g id="13.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="186.76,570.69 338.96,539.08"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(218.58,564.08)">
+            <desc>LINE_S2S3</desc>
+            <g id="13.1" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-139.41,221.67 4.10,161.60"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-109.43,209.12)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(78.27)">
+                        <g transform="rotate(67.29)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-11.73)" x="19.00">110</text>
+                        <text transform="rotate(-22.71)" x="19.00">110</text>
                     </g>
                 </g>
             </g>
-            <g id="13.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="491.16,507.48 338.96,539.08"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(459.34,514.09)">
+            <g id="13.2" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="147.61,101.53 4.10,161.60"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(117.63,114.08)">
                     <g class="nad-active nad-state-in">
-                        <g transform="rotate(-101.73)">
+                        <g transform="rotate(-112.71)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-11.73)" x="-19.00" style="text-anchor:end">-110</text>
+                        <text transform="rotate(-22.71)" x="-19.00" style="text-anchor:end">-110</text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="14">
-            <g id="14.1" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="543.56,512.26 699.86,575.90"/>
-                <g class="nad-glued-1 nad-edge-infos" transform="translate(573.66,524.52)">
+            <desc>LINE_S3S4</desc>
+            <g id="14.1" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="192.56,105.52 334.24,197.00"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(219.86,123.15)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(112.15)">
+                        <g transform="rotate(122.85)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(22.15)" x="19.00">240</text>
+                        <text transform="rotate(32.85)" x="19.00">240</text>
                     </g>
                 </g>
             </g>
-            <g id="14.2" class="nad-vl300to500-line">
-                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="856.16,639.54 699.86,575.90"/>
-                <g class="nad-glued-2 nad-edge-infos" transform="translate(826.06,627.29)">
+            <g id="14.2" class="nad-vl300to500">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="475.92,288.48 334.24,197.00"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(448.62,270.85)">
                     <g class="nad-active nad-state-in">
-                        <g transform="rotate(-67.85)">
+                        <g transform="rotate(-57.15)">
                             <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
                             <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
                         </g>
-                        <text transform="rotate(-337.85)" x="-19.00" style="text-anchor:end">-240</text>
+                        <text transform="rotate(-327.15)" x="-19.00" style="text-anchor:end">-240</text>
                     </g>
                 </g>
             </g>
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0-textedge" points="145.27,-159.19 215.60,-169.74"/>
-        <polyline id="2-textedge" points="268.24,213.82 338.57,203.27"/>
-        <polyline id="4-textedge" points="189.50,571.83 259.83,561.28"/>
-        <polyline id="6-textedge" points="547.76,497.44 618.09,486.89"/>
-        <polyline id="8-textedge" points="911.29,645.46 981.63,634.91"/>
+        <polyline id="0-textedge" points="-190.74,-519.59 -120.40,-530.14"/>
+        <polyline id="2-textedge" points="-122.67,-138.25 -52.34,-148.80"/>
+        <polyline id="4-textedge" points="-133.26,227.06 -62.93,216.51"/>
+        <polyline id="6-textedge" points="200.80,87.24 271.13,76.69"/>
+        <polyline id="8-textedge" points="527.01,297.86 597.34,287.31"/>
     </g>
     <g class="nad-text-nodes">
-        <foreignObject id="0-textnode" y="-194.74" x="215.60" height="1" width="1">
+        <foreignObject id="0-textnode" y="-555.14" x="-120.40" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>S1VL1</div>
                 <table>
                     <tr>
                         <td>
-                            <div class="nad-vl180to300-0 nad-legend-square"/>
+                            <div class="nad-legend-square"/>
                         </td>
                         <td>224.6 kV / 2.3°</td>
                     </tr>
                 </table>
             </div>
         </foreignObject>
-        <foreignObject id="2-textnode" y="178.27" x="338.57" height="1" width="1">
+        <foreignObject id="2-textnode" y="-173.80" x="-52.34" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>S1VL2</div>
                 <table>
                     <tr>
                         <td>
-                            <div class="nad-vl300to500-0 nad-legend-square"/>
+                            <div class="nad-legend-square"/>
                         </td>
                         <td>400.0 kV / 0.0°</td>
                     </tr>
                 </table>
             </div>
         </foreignObject>
-        <foreignObject id="4-textnode" y="536.28" x="259.83" height="1" width="1">
+        <foreignObject id="4-textnode" y="191.51" x="-62.93" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>S2VL1</div>
                 <table>
                     <tr>
                         <td>
-                            <div class="nad-vl300to500-0 nad-legend-square"/>
+                            <div class="nad-legend-square"/>
                         </td>
                         <td>408.8 kV / 0.7°</td>
                     </tr>
                 </table>
             </div>
         </foreignObject>
-        <foreignObject id="6-textnode" y="461.89" x="618.09" height="1" width="1">
+        <foreignObject id="6-textnode" y="51.69" x="271.13" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>S3VL1</div>
                 <table>
                     <tr>
                         <td>
-                            <div class="nad-vl300to500-0 nad-legend-square"/>
+                            <div class="nad-legend-square"/>
                         </td>
                         <td>400.0 kV / 0.0°</td>
                     </tr>
                 </table>
             </div>
         </foreignObject>
-        <foreignObject id="8-textnode" y="609.91" x="981.63" height="1" width="1">
+        <foreignObject id="8-textnode" y="262.31" x="597.34" height="1" width="1">
             <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
                 <div>S4VL1</div>
                 <table>
                     <tr>
                         <td>
-                            <div class="nad-vl300to500-0 nad-legend-square"/>
+                            <div class="nad-legend-square"/>
                         </td>
                         <td>400.0 kV / -1.1°</td>
                     </tr>

--- a/demo/src/diagram-viewers/data/nad-ieee14cdf-solved.svg
+++ b/demo/src/diagram-viewers/data/nad-ieee14cdf-solved.svg
@@ -1,0 +1,916 @@
+<svg viewBox="-773.57 -884.23 1767.75 1503.47" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-text-edges {stroke: black; stroke-width: 3; stroke-dasharray: 6,7}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
+.nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
+.nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 40}
+.nad-branch-edges .nad-tie-line-edge .nad-edge-path {stroke-width: 7}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-reactive path {stroke: none; fill: #0277bd}
+.nad-current path {stroke: none; fill: #bd4802}
+.nad-text-background {flood-color: #90a4aeaa}
+.nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
+.nad-text-nodes foreignObject {overflow: visible; color: black}
+.nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
+.nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
+.nad-disconnected {--nad-vl-color: #808080}
+.nad-vl0to30-line {--nad-vl-color: #afb42b}
+.nad-vl0to30-0 {--nad-vl-color: #827717}
+.nad-vl0to30-1 {--nad-vl-color: #d4e157}
+.nad-vl0to30-2 {--nad-vl-color: #e6ee9c}
+.nad-vl0to30-3 {--nad-vl-color: #c0ca33}
+.nad-vl0to30-4 {--nad-vl-color: #f0fc83}
+.nad-vl0to30-5 {--nad-vl-color: #9e9d24}
+.nad-vl0to30-6 {--nad-vl-color: #cddc39}
+.nad-vl0to30-7 {--nad-vl-color: #dce775}
+.nad-vl0to30-8 {--nad-vl-color: #ddfc88}
+.nad-vl30to50-line {--nad-vl-color: #ef9a9a}
+.nad-vl30to50-0 {--nad-vl-color: #c2185b}
+.nad-vl30to50-1 {--nad-vl-color: #f06292}
+.nad-vl30to50-2 {--nad-vl-color: #d81b60}
+.nad-vl30to50-3 {--nad-vl-color: #ec407a}
+.nad-vl30to50-4 {--nad-vl-color: #880e4f}
+.nad-vl30to50-5 {--nad-vl-color: #ad1457}
+.nad-vl30to50-6 {--nad-vl-color: #e91e63}
+.nad-vl30to50-7 {--nad-vl-color: #f48fb1}
+.nad-vl30to50-8 {--nad-vl-color: #f8bbd0}
+.nad-vl50to70-line {--nad-vl-color: #9c27b0}
+.nad-vl50to70-0 {--nad-vl-color: #7b1fa2}
+.nad-vl50to70-1 {--nad-vl-color: #ba68c8}
+.nad-vl50to70-2 {--nad-vl-color: #512da8}
+.nad-vl50to70-3 {--nad-vl-color: #ab47bc}
+.nad-vl50to70-4 {--nad-vl-color: #e1bee7}
+.nad-vl50to70-5 {--nad-vl-color: #6a1b9a}
+.nad-vl50to70-6 {--nad-vl-color: #4a148c}
+.nad-vl50to70-7 {--nad-vl-color: #ce93d8}
+.nad-vl50to70-8 {--nad-vl-color: #9575cd}
+.nad-vl70to120-line {--nad-vl-color: #e65100}
+.nad-vl70to120-0 {--nad-vl-color: #fb8c00}
+.nad-vl70to120-1 {--nad-vl-color: #ffb74d}
+.nad-vl70to120-2 {--nad-vl-color: #f57c00}
+.nad-vl70to120-3 {--nad-vl-color: #ffa726}
+.nad-vl70to120-4 {--nad-vl-color: #ffe0b2}
+.nad-vl70to120-5 {--nad-vl-color: #ef6c00}
+.nad-vl70to120-6 {--nad-vl-color: #ff9800}
+.nad-vl70to120-7 {--nad-vl-color: #ffcc80}
+.nad-vl70to120-8 {--nad-vl-color: #fff3e0}
+.nad-vl120to180-line {--nad-vl-color: #00ACC1}
+.nad-vl120to180-0 {--nad-vl-color: #4fc3f7}
+.nad-vl120to180-1 {--nad-vl-color: #01579b}
+.nad-vl120to180-2 {--nad-vl-color: #b3e5fc}
+.nad-vl120to180-3 {--nad-vl-color: #039be5}
+.nad-vl120to180-4 {--nad-vl-color: #81d4fa}
+.nad-vl120to180-5 {--nad-vl-color: #0288d1}
+.nad-vl120to180-6 {--nad-vl-color: #29b6f6}
+.nad-vl120to180-7 {--nad-vl-color: #0277bd}
+.nad-vl120to180-8 {--nad-vl-color: #03a9f4}
+.nad-vl180to300-line {--nad-vl-color: #2e7d32}
+.nad-vl180to300-0 {--nad-vl-color: #81c784}
+.nad-vl180to300-1 {--nad-vl-color: #558b2f}
+.nad-vl180to300-2 {--nad-vl-color: #c8e6c9}
+.nad-vl180to300-3 {--nad-vl-color: #43a047}
+.nad-vl180to300-4 {--nad-vl-color: #a5d6a7}
+.nad-vl180to300-5 {--nad-vl-color: #388e3c}
+.nad-vl180to300-6 {--nad-vl-color: #66bb6a}
+.nad-vl180to300-7 {--nad-vl-color: #1b5e20}
+.nad-vl180to300-8 {--nad-vl-color: #4caf50}
+.nad-vl300to500-line {--nad-vl-color: #d32f2f}
+.nad-vl300to500-0 {--nad-vl-color: #ef5350}
+.nad-vl300to500-1 {--nad-vl-color: #ef9a9a}
+.nad-vl300to500-2 {--nad-vl-color: #b71c1c}
+.nad-vl300to500-3 {--nad-vl-color: #e57373}
+.nad-vl300to500-4 {--nad-vl-color: #e53935}
+.nad-vl300to500-5 {--nad-vl-color: #ff8a80}
+.nad-vl300to500-6 {--nad-vl-color: #f44336}
+.nad-vl300to500-7 {--nad-vl-color: #ffcdd2}
+.nad-vl300to500-8 {--nad-vl-color: #c62828}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
+.nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
+.nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+
+@keyframes line-blink {
+  0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}
+  40% {stroke: #FFEB3B; stroke-width: 15}
+}
+@keyframes node-over-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #ff5722; stroke-width: 15}
+}
+@keyframes node-under-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #00BCD4; stroke-width: 15}
+}
+]]></style>
+    <metadata>
+        <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
+            <nad:busNodes>
+                <nad:busNode svgId="1" equipmentId="VL1_0" nbNeighbours="0" index="0" vlNode="0"/>
+                <nad:busNode svgId="3" equipmentId="VL10_0" nbNeighbours="0" index="0" vlNode="2"/>
+                <nad:busNode svgId="5" equipmentId="VL11_0" nbNeighbours="0" index="0" vlNode="4"/>
+                <nad:busNode svgId="7" equipmentId="VL12_0" nbNeighbours="0" index="0" vlNode="6"/>
+                <nad:busNode svgId="9" equipmentId="VL13_0" nbNeighbours="0" index="0" vlNode="8"/>
+                <nad:busNode svgId="11" equipmentId="VL14_0" nbNeighbours="0" index="0" vlNode="10"/>
+                <nad:busNode svgId="13" equipmentId="VL2_0" nbNeighbours="0" index="0" vlNode="12"/>
+                <nad:busNode svgId="15" equipmentId="VL3_0" nbNeighbours="0" index="0" vlNode="14"/>
+                <nad:busNode svgId="18" equipmentId="VL4_1" nbNeighbours="2" index="0" vlNode="16"/>
+                <nad:busNode svgId="19" equipmentId="VL4_2" nbNeighbours="2" index="1" vlNode="16"/>
+                <nad:busNode svgId="17" equipmentId="VL4_0" nbNeighbours="2" index="2" vlNode="16"/>
+                <nad:busNode svgId="21" equipmentId="VL5_0" nbNeighbours="1" index="0" vlNode="20"/>
+                <nad:busNode svgId="22" equipmentId="VL5_1" nbNeighbours="1" index="1" vlNode="20"/>
+                <nad:busNode svgId="24" equipmentId="VL8_0" nbNeighbours="0" index="0" vlNode="23"/>
+            </nad:busNodes>
+            <nad:nodes>
+                <nad:node svgId="0" equipmentId="VL1" x="182.16" y="-669.23"/>
+                <nad:node svgId="2" equipmentId="VL10" x="-573.57" y="100.52"/>
+                <nad:node svgId="4" equipmentId="VL11" x="-295.68" y="308.31"/>
+                <nad:node svgId="6" equipmentId="VL12" x="694.18" y="76.12"/>
+                <nad:node svgId="8" equipmentId="VL13" x="468.40" y="333.92"/>
+                <nad:node svgId="10" equipmentId="VL14" x="112.11" y="419.24"/>
+                <nad:node svgId="12" equipmentId="VL2" x="62.40" y="-384.58"/>
+                <nad:node svgId="14" equipmentId="VL3" x="379.01" y="-360.27"/>
+                <nad:node svgId="16" equipmentId="VL4" x="-140.21" y="-108.15"/>
+                <nad:node svgId="20" equipmentId="VL5" x="202.16" y="-30.06"/>
+                <nad:node svgId="23" equipmentId="VL8" x="-520.85" y="-451.48"/>
+            </nad:nodes>
+            <nad:edges>
+                <nad:edge svgId="25" equipmentId="L1-2-1" node1="0" node2="12" busNode1="1" busNode2="13"/>
+                <nad:edge svgId="26" equipmentId="L1-5-1" node1="0" node2="20" busNode1="1" busNode2="21"/>
+                <nad:edge svgId="27" equipmentId="L9-10-1" node1="16" node2="2" busNode1="19" busNode2="3"/>
+                <nad:edge svgId="28" equipmentId="L10-11-1" node1="2" node2="4" busNode1="3" busNode2="5"/>
+                <nad:edge svgId="29" equipmentId="L6-11-1" node1="20" node2="4" busNode1="22" busNode2="5"/>
+                <nad:edge svgId="30" equipmentId="L6-12-1" node1="20" node2="6" busNode1="22" busNode2="7"/>
+                <nad:edge svgId="31" equipmentId="L12-13-1" node1="6" node2="8" busNode1="7" busNode2="9"/>
+                <nad:edge svgId="32" equipmentId="L6-13-1" node1="20" node2="8" busNode1="22" busNode2="9"/>
+                <nad:edge svgId="33" equipmentId="L13-14-1" node1="8" node2="10" busNode1="9" busNode2="11"/>
+                <nad:edge svgId="34" equipmentId="L9-14-1" node1="16" node2="10" busNode1="19" busNode2="11"/>
+                <nad:edge svgId="35" equipmentId="L2-3-1" node1="12" node2="14" busNode1="13" busNode2="15"/>
+                <nad:edge svgId="36" equipmentId="L2-4-1" node1="12" node2="16" busNode1="13" busNode2="17"/>
+                <nad:edge svgId="37" equipmentId="L2-5-1" node1="12" node2="20" busNode1="13" busNode2="21"/>
+                <nad:edge svgId="38" equipmentId="L3-4-1" node1="14" node2="16" busNode1="15" busNode2="17"/>
+                <nad:edge svgId="39" equipmentId="L4-5-1" node1="16" node2="20" busNode1="17" busNode2="21"/>
+                <nad:edge svgId="40" equipmentId="L7-8-1" node1="16" node2="23" busNode1="18" busNode2="24"/>
+                <nad:edge svgId="41" equipmentId="L7-9-1" node1="16" node2="16" busNode1="18" busNode2="19"/>
+                <nad:edge svgId="42" equipmentId="T4-7-1" node1="16" node2="16" busNode1="17" busNode2="18"/>
+                <nad:edge svgId="43" equipmentId="T4-9-1" node1="16" node2="16" busNode1="17" busNode2="19"/>
+                <nad:edge svgId="44" equipmentId="T5-6-1" node1="20" node2="20" busNode1="21" busNode2="22"/>
+            </nad:edges>
+        </nad:nad>
+    </metadata>
+    <g class="nad-vl-nodes">
+        <g transform="translate(182.16,-669.23)" id="0">
+            <circle r="27.50" id="1" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+        <g transform="translate(-573.57,100.52)" id="2">
+            <circle r="27.50" id="3" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+        <g transform="translate(-295.68,308.31)" id="4">
+            <circle r="27.50" id="5" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+        <g transform="translate(694.18,76.12)" id="6">
+            <circle r="27.50" id="7" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+        <g transform="translate(468.40,333.92)" id="8">
+            <circle r="27.50" id="9" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+        <g transform="translate(112.11,419.24)" id="10">
+            <circle r="27.50" id="11" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+        <g transform="translate(62.40,-384.58)" id="12">
+            <circle r="27.50" id="13" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+        <g transform="translate(379.01,-360.27)" id="14">
+            <circle r="27.50" id="15" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+        <g transform="translate(-140.21,-108.15)" id="16">
+            <circle r="17.50" id="18" class="nad-vl0to30-0 nad-busnode"/>
+            <path d="M0.536,-37.496 A37.500,37.500 157.082 0 1 14.108,34.745 L11.161,19.537 A22.500,22.500 -141.803 0 0 3.310,-22.255 Z M-0.536,37.496 A37.500,37.500 119.772 0 1 -32.281,-19.084 L-20.719,-8.774 A22.500,22.500 -104.493 0 0 -3.310,22.255 Z " id="19" class="nad-vl0to30-1 nad-busnode"/>
+            <path d="M-37.325,-43.739 A57.500,57.500 22.363 0 1 -17.877,-54.651 L-15.058,-39.743 A42.500,42.500 -17.088 0 0 -26.071,-33.564 Z M-3.176,-57.412 A57.500,57.500 105.053 0 1 56.267,11.844 L41.947,6.831 A42.500,42.500 -99.778 0 0 -0.392,-42.498 Z M51.309,25.955 A57.500,57.500 30.125 0 1 31.352,48.201 L24.788,34.522 A42.500,42.500 -24.849 0 0 37.001,20.909 Z M3.176,57.412 A57.500,57.500 45.053 0 1 -38.390,42.807 L-26.889,32.912 A42.500,42.500 -39.778 0 0 0.392,42.498 Z M-54.611,17.995 A57.500,57.500 52.815 0 1 -47.344,-32.632 L-36.066,-22.483 A42.500,42.500 -47.539 0 0 -40.934,11.429 Z " id="17" class="nad-vl0to30-2 nad-busnode"/>
+        </g>
+        <g transform="translate(202.16,-30.06)" id="20">
+            <circle r="27.50" id="21" class="nad-vl0to30-0 nad-busnode"/>
+            <path d="M-53.921,-19.968 A57.500,57.500 40.691 0 1 -27.866,-50.296 L-18.519,-26.708 A32.500,32.500 -29.193 0 0 -29.194,-14.282 Z M26.699,-50.926 A57.500,57.500 247.707 1 1 -57.247,-5.385 L-32.499,0.213 A32.500,32.500 -236.210 1 0 17.898,-27.128 Z " id="22" class="nad-vl0to30-1 nad-busnode"/>
+        </g>
+        <g transform="translate(-520.85,-451.48)" id="23">
+            <circle r="27.50" id="24" class="nad-vl0to30-0 nad-busnode"/>
+        </g>
+    </g>
+    <g class="nad-branch-edges">
+        <g id="25">
+            <g id="25.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="171.49,-643.88 122.28,-526.91"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(158.89,-613.92)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-157.18)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-67.18)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="25.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="73.07,-409.93 122.28,-526.91"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(85.67,-439.89)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(22.82)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-67.18)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="26">
+            <g id="26.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="183.02,-641.74 192.16,-349.65"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(184.04,-609.26)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(178.21)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(88.21)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="26.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="201.30,-57.55 192.16,-349.65"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(199.34,-120.02)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-1.79)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-271.79)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="27">
+            <g id="27.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-174.00,-91.88 -361.39,-1.64"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-221.30,-69.10)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-115.71)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-25.71)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="27.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-548.79,88.59 -361.39,-1.64"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-519.51,74.49)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(64.29)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-25.71)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="28">
+            <g id="28.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-551.54,116.99 -434.62,204.42"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-525.51,136.45)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(126.79)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(36.79)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="28.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-317.70,291.84 -434.62,204.42"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-343.73,272.38)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-53.21)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-323.21)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="29">
+            <g id="29.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="154.60,2.26 -59.17,147.56"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(127.72,20.53)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-124.20)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-34.20)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="29.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-272.94,292.85 -59.17,147.56"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-246.06,274.59)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(55.80)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-34.20)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="30">
+            <g id="30.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="258.36,-17.93 462.83,26.19"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(290.13,-11.08)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(102.18)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(12.18)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="30.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="667.30,70.32 462.83,26.19"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(635.54,63.47)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-77.82)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-347.82)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="31">
+            <g id="31.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="676.07,96.81 581.29,205.02"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(654.65,121.26)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-138.79)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-48.79)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="31.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="486.52,313.23 581.29,205.02"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(507.94,288.78)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(41.21)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-48.79)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="32">
+            <g id="32.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="236.11,16.34 344.14,164.03"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(255.29,42.58)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(143.82)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(53.82)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="32.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="452.17,311.72 344.14,164.03"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(432.98,285.49)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-36.18)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-306.18)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="33">
+            <g id="33.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="441.66,340.32 290.26,376.58"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(410.05,347.89)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-103.47)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-13.47)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="33.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="138.86,412.83 290.26,376.58"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(170.46,405.27)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(76.53)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-13.47)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="34">
+            <g id="34.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-124.03,-74.32 -11.89,160.06"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-101.37,-26.96)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(154.43)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(64.43)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="34.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="100.24,394.43 -11.89,160.06"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(86.22,365.11)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-25.57)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-295.57)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="35">
+            <g id="35.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="89.82,-382.48 220.71,-372.43"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(122.23,-379.99)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(94.39)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(4.39)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="35.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="351.59,-362.38 220.71,-372.43"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(319.19,-364.87)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-85.61)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-355.61)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="36">
+            <g id="36.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="46.15,-362.40 -30.04,-258.46"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(26.93,-336.19)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-143.76)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-53.76)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="36.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-106.22,-154.52 -30.04,-258.46"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-87.01,-180.74)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(36.24)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-53.76)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="37">
+            <g id="37.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="72.49,-359.00 132.28,-207.32"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(84.41,-328.76)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(158.48)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(68.48)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="37.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="192.07,-55.65 132.28,-207.32"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(169.15,-113.79)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-21.52)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-291.52)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="38">
+            <g id="38.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="354.27,-348.26 132.89,-240.76"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(325.04,-334.06)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-115.90)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-25.90)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="38.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-88.49,-133.26 132.89,-240.76"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-59.25,-147.46)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(64.10)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-25.90)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="39">
+            <g id="39.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-84.15,-95.36 45.60,-65.77"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-52.46,-88.13)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(102.85)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(12.85)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="39.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="175.35,-36.18 45.60,-65.77"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(114.41,-50.08)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-77.15)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-347.15)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="40">
+            <g id="40.1" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-153.20,-119.87 -326.82,-276.46"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-207.04,-168.43)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-47.95)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-317.95)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="40.2" class="nad-vl0to30-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-500.43,-433.06 -326.82,-276.46"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-476.30,-411.29)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(132.05)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(42.05)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="41">
+            <g id="41.1" class="nad-vl0to30-line">
+                <path class="nad-edge-path" d="M-136.98,-90.95 L-125.44,-29.52 C-118.05,9.79 -142.25,18.33 -179.99,5.07"/>
+                <g class="nad-edge-infos" transform="translate(-125.44,-29.52)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(169.36)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(79.36)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="41.2" class="nad-vl0to30-line">
+                <path class="nad-edge-path" d="M-168.67,-83.72 L-200.92,-56.04 C-231.27,-29.99 -217.73,-8.19 -179.99,5.07"/>
+                <g class="nad-edge-infos" transform="translate(-200.92,-56.04)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-130.64)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-40.64)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="42">
+            <g id="42.1" class="nad-vl0to30-line">
+                <path class="nad-edge-path" d="M-194.46,-127.21 L-215.69,-134.67 C-253.42,-147.93 -248.72,-173.15 -241.13,-179.67"/>
+                <g class="nad-edge-infos" transform="translate(-215.69,-134.67)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-70.64)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-340.64)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="42.2" class="nad-vl0to30-line">
+                <path class="nad-edge-path" d="M-143.44,-125.35 L-154.98,-186.77 C-162.37,-226.08 -188.01,-225.26 -195.60,-218.74"/>
+                <g class="nad-edge-infos" transform="translate(-154.98,-186.77)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-10.64)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-280.64)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <circle class="nad-vl0to30-line nad-winding" cx="-225.95" cy="-192.69" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="-210.78" cy="-205.72" r="20.00"/>
+            </g>
+        </g>
+        <g id="43">
+            <g id="43.1" class="nad-vl0to30-line">
+                <path class="nad-edge-path" d="M-96.58,-145.60 L-79.50,-160.25 C-49.15,-186.30 -29.66,-169.61 -27.81,-159.79"/>
+                <g class="nad-edge-infos" transform="translate(-79.50,-160.25)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(49.36)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-40.64)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="43.2" class="nad-vl0to30-line">
+                <path class="nad-edge-path" d="M-104.83,-95.71 L-64.73,-81.63 C-27.00,-68.37 -14.89,-90.99 -16.73,-100.82"/>
+                <g class="nad-edge-infos" transform="translate(-64.73,-81.63)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(109.36)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(19.36)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <circle class="nad-vl0to30-line nad-winding" cx="-24.12" cy="-140.13" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="-20.43" cy="-120.47" r="20.00"/>
+            </g>
+        </g>
+        <g id="44">
+            <g id="44.1" class="nad-vl0to30-line">
+                <path class="nad-edge-path" d="M211.65,-55.87 L229.77,-105.15 C243.58,-142.69 268.74,-137.62 275.14,-129.94"/>
+                <g class="nad-edge-infos" transform="translate(229.77,-105.15)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(20.19)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-69.81)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="44.2" class="nad-vl0to30-line">
+                <path class="nad-edge-path" d="M258.82,-39.86 L280.99,-43.69 C320.40,-50.50 319.95,-76.16 313.55,-83.84"/>
+                <g class="nad-edge-infos" transform="translate(280.99,-43.69)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(80.19)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-9.81)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <circle class="nad-vl0to30-line nad-winding" cx="287.94" cy="-114.57" r="20.00"/>
+                <circle class="nad-vl0to30-line nad-winding" cx="300.75" cy="-99.21" r="20.00"/>
+            </g>
+        </g>
+    </g>
+    <g class="nad-text-edges">
+        <polyline id="0-textedge" points="211.83,-673.68 282.16,-684.23"/>
+        <polyline id="2-textedge" points="-543.90,96.07 -473.57,85.52"/>
+        <polyline id="4-textedge" points="-266.01,303.86 -195.68,293.31"/>
+        <polyline id="6-textedge" points="723.85,71.67 794.18,61.12"/>
+        <polyline id="8-textedge" points="498.07,329.47 568.40,318.92"/>
+        <polyline id="10-textedge" points="141.78,414.79 212.11,404.24"/>
+        <polyline id="12-textedge" points="92.07,-389.03 162.40,-399.58"/>
+        <polyline id="14-textedge" points="408.68,-364.72 479.01,-375.27"/>
+        <polyline id="16-textedge" points="-80.87,-117.05 -40.21,-123.15"/>
+        <polyline id="20-textedge" points="261.49,-38.97 302.16,-45.06"/>
+        <polyline id="23-textedge" points="-491.18,-455.93 -420.85,-466.48"/>
+    </g>
+    <g class="nad-text-nodes">
+        <foreignObject id="0-textnode" y="-709.23" x="282.16" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL1</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>1.1 kV / 0.0°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="2-textnode" y="60.52" x="-473.57" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL10</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>1.1 kV / -15.1°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="4-textnode" y="268.31" x="-195.68" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL11</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>1.1 kV / -14.8°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="6-textnode" y="36.12" x="794.18" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL12</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>1.1 kV / -15.1°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="8-textnode" y="293.92" x="568.40" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL13</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>1.1 kV / -15.2°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="10-textnode" y="379.24" x="212.11" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL14</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>1.0 kV / -16.0°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="12-textnode" y="-424.58" x="162.40" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL2</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>1.0 kV / -5.0°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="14-textnode" y="-400.27" x="479.01" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL3</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>1.0 kV / -12.7°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="16-textnode" y="-148.15" x="-40.21" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL4</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>1.1 kV / -13.4°</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-1 nad-legend-square"/>
+                        </td>
+                        <td>1.1 kV / -14.9°</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-2 nad-legend-square"/>
+                        </td>
+                        <td>1.0 kV / -10.3°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="20-textnode" y="-70.06" x="302.16" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL5</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>1.0 kV / -8.8°</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-1 nad-legend-square"/>
+                        </td>
+                        <td>1.1 kV / -14.2°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="23-textnode" y="-491.48" x="-420.85" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL8</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl0to30-0 nad-legend-square"/>
+                        </td>
+                        <td>1.1 kV / -13.4°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+    </g>
+</svg>

--- a/demo/src/diagram-viewers/data/nad-ieee9-zeroimpedance-cdf.svg
+++ b/demo/src/diagram-viewers/data/nad-ieee9-zeroimpedance-cdf.svg
@@ -1,0 +1,514 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="-483.06 -586.47 1096.85 1076.86" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-text-edges {stroke: black; stroke-width: 3; stroke-dasharray: 6,7}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
+.nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
+.nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 40}
+.nad-branch-edges .nad-tie-line-edge .nad-edge-path {stroke-width: 7}
+.nad-pst-arrow {stroke: #6a6a6a; stroke-width: 4; stroke-linecap: round; fill: none}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-reactive path {stroke: none; fill: #0277bd}
+.nad-current path {stroke: none; fill: #bd4802}
+.nad-text-background {flood-color: #90a4aeaa}
+.nad-text-nodes {font: 25px serif; fill: black; dominant-baseline: central}
+.nad-text-nodes foreignObject {overflow: visible; color: black}
+.nad-label-box {background-color: #6c6c6c20; width: max-content; padding: 10px; border-radius: 10px;}
+.nad-legend-square {width: 20px; height: 20px; background: var(--nad-vl-color, black);}
+.nad-edge-infos text, .nad-edge-label text {font: 20px serif; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 10; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
+.nad-disconnected {--nad-vl-color: #808080}
+.nad-vl0to30-line {--nad-vl-color: #afb42b}
+.nad-vl0to30-0 {--nad-vl-color: #827717}
+.nad-vl0to30-1 {--nad-vl-color: #d4e157}
+.nad-vl0to30-2 {--nad-vl-color: #e6ee9c}
+.nad-vl0to30-3 {--nad-vl-color: #c0ca33}
+.nad-vl0to30-4 {--nad-vl-color: #f0fc83}
+.nad-vl0to30-5 {--nad-vl-color: #9e9d24}
+.nad-vl0to30-6 {--nad-vl-color: #cddc39}
+.nad-vl0to30-7 {--nad-vl-color: #dce775}
+.nad-vl0to30-8 {--nad-vl-color: #ddfc88}
+.nad-vl30to50-line {--nad-vl-color: #ef9a9a}
+.nad-vl30to50-0 {--nad-vl-color: #c2185b}
+.nad-vl30to50-1 {--nad-vl-color: #f06292}
+.nad-vl30to50-2 {--nad-vl-color: #d81b60}
+.nad-vl30to50-3 {--nad-vl-color: #ec407a}
+.nad-vl30to50-4 {--nad-vl-color: #880e4f}
+.nad-vl30to50-5 {--nad-vl-color: #ad1457}
+.nad-vl30to50-6 {--nad-vl-color: #e91e63}
+.nad-vl30to50-7 {--nad-vl-color: #f48fb1}
+.nad-vl30to50-8 {--nad-vl-color: #f8bbd0}
+.nad-vl50to70-line {--nad-vl-color: #9c27b0}
+.nad-vl50to70-0 {--nad-vl-color: #7b1fa2}
+.nad-vl50to70-1 {--nad-vl-color: #ba68c8}
+.nad-vl50to70-2 {--nad-vl-color: #512da8}
+.nad-vl50to70-3 {--nad-vl-color: #ab47bc}
+.nad-vl50to70-4 {--nad-vl-color: #e1bee7}
+.nad-vl50to70-5 {--nad-vl-color: #6a1b9a}
+.nad-vl50to70-6 {--nad-vl-color: #4a148c}
+.nad-vl50to70-7 {--nad-vl-color: #ce93d8}
+.nad-vl50to70-8 {--nad-vl-color: #9575cd}
+.nad-vl70to120-line {--nad-vl-color: #e65100}
+.nad-vl70to120-0 {--nad-vl-color: #fb8c00}
+.nad-vl70to120-1 {--nad-vl-color: #ffb74d}
+.nad-vl70to120-2 {--nad-vl-color: #f57c00}
+.nad-vl70to120-3 {--nad-vl-color: #ffa726}
+.nad-vl70to120-4 {--nad-vl-color: #ffe0b2}
+.nad-vl70to120-5 {--nad-vl-color: #ef6c00}
+.nad-vl70to120-6 {--nad-vl-color: #ff9800}
+.nad-vl70to120-7 {--nad-vl-color: #ffcc80}
+.nad-vl70to120-8 {--nad-vl-color: #fff3e0}
+.nad-vl120to180-line {--nad-vl-color: #00ACC1}
+.nad-vl120to180-0 {--nad-vl-color: #4fc3f7}
+.nad-vl120to180-1 {--nad-vl-color: #01579b}
+.nad-vl120to180-2 {--nad-vl-color: #b3e5fc}
+.nad-vl120to180-3 {--nad-vl-color: #039be5}
+.nad-vl120to180-4 {--nad-vl-color: #81d4fa}
+.nad-vl120to180-5 {--nad-vl-color: #0288d1}
+.nad-vl120to180-6 {--nad-vl-color: #29b6f6}
+.nad-vl120to180-7 {--nad-vl-color: #0277bd}
+.nad-vl120to180-8 {--nad-vl-color: #03a9f4}
+.nad-vl180to300-line {--nad-vl-color: #2e7d32}
+.nad-vl180to300-0 {--nad-vl-color: #81c784}
+.nad-vl180to300-1 {--nad-vl-color: #558b2f}
+.nad-vl180to300-2 {--nad-vl-color: #c8e6c9}
+.nad-vl180to300-3 {--nad-vl-color: #43a047}
+.nad-vl180to300-4 {--nad-vl-color: #a5d6a7}
+.nad-vl180to300-5 {--nad-vl-color: #388e3c}
+.nad-vl180to300-6 {--nad-vl-color: #66bb6a}
+.nad-vl180to300-7 {--nad-vl-color: #1b5e20}
+.nad-vl180to300-8 {--nad-vl-color: #4caf50}
+.nad-vl300to500-line {--nad-vl-color: #d32f2f}
+.nad-vl300to500-0 {--nad-vl-color: #ef5350}
+.nad-vl300to500-1 {--nad-vl-color: #ef9a9a}
+.nad-vl300to500-2 {--nad-vl-color: #b71c1c}
+.nad-vl300to500-3 {--nad-vl-color: #e57373}
+.nad-vl300to500-4 {--nad-vl-color: #e53935}
+.nad-vl300to500-5 {--nad-vl-color: #ff8a80}
+.nad-vl300to500-6 {--nad-vl-color: #f44336}
+.nad-vl300to500-7 {--nad-vl-color: #ffcdd2}
+.nad-vl300to500-8 {--nad-vl-color: #c62828}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
+.nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
+.nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+
+@keyframes line-blink {
+  0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 5}
+  40% {stroke: #FFEB3B; stroke-width: 15}
+}
+@keyframes node-over-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #ff5722; stroke-width: 15}
+}
+@keyframes node-under-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #00BCD4; stroke-width: 15}
+}
+]]></style>
+    <metadata>
+        <nad:nad xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
+            <nad:busNodes>
+                <nad:busNode svgId="1" equipmentId="VL1_0" nbNeighbours="1" index="0" vlNode="0"/>
+                <nad:busNode svgId="2" equipmentId="VL1_1" nbNeighbours="1" index="1" vlNode="0"/>
+                <nad:busNode svgId="4" equipmentId="VL2_0" nbNeighbours="2" index="0" vlNode="3"/>
+                <nad:busNode svgId="6" equipmentId="VL2_2" nbNeighbours="2" index="1" vlNode="3"/>
+                <nad:busNode svgId="5" equipmentId="VL2_1" nbNeighbours="2" index="2" vlNode="3"/>
+                <nad:busNode svgId="8" equipmentId="VL3_0" nbNeighbours="1" index="0" vlNode="7"/>
+                <nad:busNode svgId="9" equipmentId="VL3_1" nbNeighbours="1" index="1" vlNode="7"/>
+                <nad:busNode svgId="11" equipmentId="VL5_0" nbNeighbours="0" index="0" vlNode="10"/>
+                <nad:busNode svgId="13" equipmentId="VL6_0" nbNeighbours="0" index="0" vlNode="12"/>
+            </nad:busNodes>
+            <nad:nodes>
+                <nad:node svgId="0" equipmentId="VL1" x="313.79" y="-123.09"/>
+                <nad:node svgId="3" equipmentId="VL2" x="-283.06" y="-90.04"/>
+                <nad:node svgId="7" equipmentId="VL3" x="-145.81" y="290.39"/>
+                <nad:node svgId="10" equipmentId="VL5" x="10.63" y="-371.47"/>
+                <nad:node svgId="12" equipmentId="VL6" x="247.51" y="268.96"/>
+            </nad:nodes>
+            <nad:edges>
+                <nad:edge svgId="14" equipmentId="L5-4-0" node1="10" node2="0" busNode1="11" busNode2="2"/>
+                <nad:edge svgId="15" equipmentId="L6-4-0" node1="12" node2="0" busNode1="13" busNode2="2"/>
+                <nad:edge svgId="16" equipmentId="T4-1-0" node1="0" node2="0" busNode1="2" busNode2="1"/>
+                <nad:edge svgId="17" equipmentId="L7-8-0" node1="3" node2="3" busNode1="5" busNode2="6"/>
+                <nad:edge svgId="18" equipmentId="L7-5-0" node1="3" node2="10" busNode1="5" busNode2="11"/>
+                <nad:edge svgId="19" equipmentId="L9-8-0" node1="7" node2="3" busNode1="9" busNode2="6"/>
+                <nad:edge svgId="20" equipmentId="T7-2-0" node1="3" node2="3" busNode1="5" busNode2="4"/>
+                <nad:edge svgId="21" equipmentId="L9-6-0" node1="7" node2="12" busNode1="9" busNode2="13"/>
+                <nad:edge svgId="22" equipmentId="T9-3-0" node1="7" node2="7" busNode1="9" busNode2="8"/>
+            </nad:edges>
+        </nad:nad>
+    </metadata>
+    <g class="nad-vl-nodes">
+        <g transform="translate(313.79,-123.09)" id="0">
+            <circle r="27.50" id="1" class="nad-vl70to120-0 nad-busnode"/>
+            <path d="M55.006,16.749 A57.500,57.500 345.053 1 1 57.465,1.995 L32.430,-2.131 A32.500,32.500 -333.556 1 0 29.986,12.534 Z " id="2" class="nad-vl70to120-1 nad-busnode"/>
+        </g>
+        <g transform="translate(-283.06,-90.04)" id="3">
+            <circle r="17.50" id="4" class="nad-vl70to120-0 nad-busnode"/>
+            <path d="M-21.696,-30.586 A37.500,37.500 337.082 1 1 -31.894,-19.723 L-20.540,-9.185 A22.500,22.500 -321.803 1 0 -10.462,-19.920 Z " id="6" class="nad-vl70to120-1 nad-busnode"/>
+            <path d="M-36.447,-44.473 A57.500,57.500 165.053 0 1 46.684,33.568 L35.611,23.197 A42.500,42.500 -159.778 0 0 -25.398,-34.077 Z M36.447,44.473 A57.500,57.500 12.024 0 1 26.383,51.090 L21.217,36.825 A42.500,42.500 -6.748 0 0 25.398,34.077 Z M12.313,56.166 A57.500,57.500 138.083 0 1 -46.684,-33.568 L-35.611,-23.197 A42.500,42.500 -132.808 0 0 7.181,41.889 Z " id="5" class="nad-vl70to120-2 nad-busnode"/>
+        </g>
+        <g transform="translate(-145.81,290.39)" id="7">
+            <circle r="27.50" id="8" class="nad-vl70to120-0 nad-busnode"/>
+            <path d="M-54.366,18.725 A57.500,57.500 345.053 1 1 -47.696,32.114 L-25.005,20.760 A32.500,32.500 -333.556 1 0 -31.634,7.453 Z " id="9" class="nad-vl70to120-1 nad-busnode"/>
+        </g>
+        <g transform="translate(10.63,-371.47)" id="10">
+            <circle r="27.50" id="11" class="nad-vl70to120-0 nad-busnode"/>
+        </g>
+        <g transform="translate(247.51,268.96)" id="12">
+            <circle r="27.50" id="13" class="nad-vl70to120-0 nad-busnode"/>
+        </g>
+    </g>
+    <g class="nad-branch-edges">
+        <g id="14">
+            <g id="14.1" class="nad-vl70to120-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="31.90,-354.04 150.61,-256.79"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(57.04,-333.44)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(129.33)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(39.33)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="14.2" class="nad-vl70to120-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="269.31,-159.53 150.61,-256.79"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(244.17,-180.13)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-50.67)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-320.67)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="15">
+            <g id="15.1" class="nad-vl70to120-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="252.09,241.84 278.15,87.73"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(257.51,209.80)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(9.60)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-80.40)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="15.2" class="nad-vl70to120-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="304.20,-66.39 278.15,87.73"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(298.79,-34.35)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-170.40)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-80.40)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="16">
+            <g id="16.1" class="nad-vl70to120-line">
+                <path class="nad-edge-path" d="M350.33,-167.48 L364.63,-184.85 C390.06,-215.73 412.13,-202.64 415.64,-193.28"/>
+                <g class="nad-edge-infos" transform="translate(364.63,-184.85)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(39.46)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-50.54)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="16.2" class="nad-vl70to120-line">
+                <path class="nad-edge-path" d="M340.91,-118.57 L392.70,-109.93 C432.16,-103.36 440.19,-127.73 436.69,-137.09"/>
+                <g class="nad-edge-infos" transform="translate(392.70,-109.93)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(99.46)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(9.46)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <circle class="nad-vl70to120-line nad-winding" cx="422.65" cy="-174.55" r="20.00"/>
+                <circle class="nad-vl70to120-line nad-winding" cx="429.67" cy="-155.82" r="20.00"/>
+            </g>
+        </g>
+        <g id="17">
+            <g id="17.1" class="nad-vl70to120-line">
+                <path class="nad-edge-path" d="M-228.02,-106.67 L-206.48,-113.17 C-168.19,-124.74 -157.10,-101.60 -166.23,-62.65"/>
+                <g class="nad-edge-infos" transform="translate(-206.48,-113.17)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(73.19)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-16.81)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="17.2" class="nad-vl70to120-line">
+                <path class="nad-edge-path" d="M-255.72,-64.37 L-224.73,-35.28 C-195.57,-7.91 -175.35,-23.71 -166.23,-62.65"/>
+                <g class="nad-edge-infos" transform="translate(-224.73,-35.28)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(133.19)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(43.19)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="18">
+            <g id="18.1" class="nad-vl70to120-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-241.54,-129.82 -125.38,-241.13"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-218.08,-152.31)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(46.22)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-43.78)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="18.2" class="nad-vl70to120-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-9.23,-352.44 -125.38,-241.13"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-32.69,-329.96)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-133.78)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-43.78)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="19">
+            <g id="19.1" class="nad-vl70to120-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-165.32,236.31 -217.83,90.77"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-176.35,205.73)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-19.84)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-289.84)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="19.2" class="nad-vl70to120-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="-270.33,-54.76 -217.83,90.77"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(-252.52,-5.38)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(160.16)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(70.16)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="20">
+            <g id="20.1" class="nad-vl70to120-line">
+                <path class="nad-edge-path" d="M-338.10,-73.41 L-359.64,-66.90 C-397.93,-55.34 -409.02,-78.48 -406.74,-88.21"/>
+                <g class="nad-edge-infos" transform="translate(-359.64,-66.90)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-106.81)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-16.81)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="20.2" class="nad-vl70to120-line">
+                <path class="nad-edge-path" d="M-295.82,-102.02 L-341.39,-144.79 C-370.55,-172.17 -390.77,-156.37 -393.05,-146.63"/>
+                <g class="nad-edge-infos" transform="translate(-341.39,-144.79)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-46.81)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-316.81)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <circle class="nad-vl70to120-line nad-winding" cx="-402.18" cy="-107.69" r="20.00"/>
+                <circle class="nad-vl70to120-line nad-winding" cx="-397.61" cy="-127.16" r="20.00"/>
+            </g>
+        </g>
+        <g id="21">
+            <g id="21.1" class="nad-vl70to120-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-1" points="-88.40,287.26 65.83,278.86"/>
+                <g class="nad-glued-1 nad-edge-infos" transform="translate(-55.94,285.50)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(86.88)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-3.12)" x="19.00"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="21.2" class="nad-vl70to120-line">
+                <polyline class="nad-edge-path nad-stretchable nad-glued-2" points="220.05,270.45 65.83,278.86"/>
+                <g class="nad-glued-2 nad-edge-infos" transform="translate(187.60,272.22)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-93.12)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-3.12)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="22">
+            <g id="22.1" class="nad-vl70to120-line">
+                <path class="nad-edge-path" d="M-149.34,347.78 L-150.72,370.24 C-153.18,410.17 -178.73,412.52 -187.07,407.00"/>
+                <g class="nad-edge-infos" transform="translate(-150.72,370.24)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-176.48)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-86.48)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g id="22.2" class="nad-vl70to120-line">
+                <path class="nad-edge-path" d="M-170.43,302.65 L-217.42,326.06 C-253.22,343.90 -245.43,368.35 -237.09,373.87"/>
+                <g class="nad-edge-infos" transform="translate(-217.42,326.06)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-116.48)">
+                            <path class="nad-arrow-in" transform="scale(10.00)" d="M-1 -1 H1 L0 1z"/>
+                            <path class="nad-arrow-out" transform="scale(10.00)" d="M-1 1 H1 L0 -1z"/>
+                        </g>
+                        <text transform="rotate(-26.48)" x="-19.00" style="text-anchor:end"></text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <circle class="nad-vl70to120-line nad-winding" cx="-203.74" cy="395.96" r="20.00"/>
+                <circle class="nad-vl70to120-line nad-winding" cx="-220.42" cy="384.91" r="20.00"/>
+            </g>
+        </g>
+    </g>
+    <g class="nad-text-edges">
+        <polyline id="0-textedge" points="373.12,-131.99 413.79,-138.09"/>
+        <polyline id="3-textedge" points="-223.72,-98.94 -183.06,-105.04"/>
+        <polyline id="7-textedge" points="-86.47,281.49 -45.81,275.39"/>
+        <polyline id="10-textedge" points="40.30,-375.92 110.63,-386.47"/>
+        <polyline id="12-textedge" points="277.18,264.51 347.51,253.96"/>
+    </g>
+    <g class="nad-text-nodes">
+        <foreignObject id="0-textnode" y="-163.09" x="413.79" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL1</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl70to120-0 nad-legend-square"/>
+                        </td>
+                        <td>104.0 kV / 0.0°</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <div class="nad-vl70to120-1 nad-legend-square"/>
+                        </td>
+                        <td>102.5 kV / -2.2°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="3-textnode" y="-130.04" x="-183.06" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL2</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl70to120-0 nad-legend-square"/>
+                        </td>
+                        <td>102.5 kV / 9.3°</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <div class="nad-vl70to120-1 nad-legend-square"/>
+                        </td>
+                        <td>101.5 kV / 0.7°</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <div class="nad-vl70to120-2 nad-legend-square"/>
+                        </td>
+                        <td>102.5 kV / 3.7°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="7-textnode" y="250.39" x="-45.81" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL3</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl70to120-0 nad-legend-square"/>
+                        </td>
+                        <td>102.5 kV / 4.7°</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <div class="nad-vl70to120-1 nad-legend-square"/>
+                        </td>
+                        <td>103.2 kV / 2.0°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="10-textnode" y="-411.47" x="110.63" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL5</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl70to120-0 nad-legend-square"/>
+                        </td>
+                        <td>99.5 kV / -4.0°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+        <foreignObject id="12-textnode" y="228.96" x="347.51" height="1" width="1">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+                <div>VL6</div>
+                <table>
+                    <tr>
+                        <td>
+                            <div class="nad-vl70to120-0 nad-legend-square"/>
+                        </td>
+                        <td>101.2 kV / -3.7°</td>
+                    </tr>
+                </table>
+            </div>
+        </foreignObject>
+    </g>
+</svg>

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -242,3 +242,138 @@ function classIsContainerOfDraggables(element: SVGElement): boolean {
         element.classList.contains('nad-3wt-nodes')
     );
 }
+
+// get inner and outer radius of bus node and radius of voltage level
+export function getNodeRadius(
+    nbNeighbours: number,
+    voltageLevelCircleRadius: number,
+    busIndex: number,
+    interAnnulusSpace: number
+): [number, number, number] {
+    const vlCircleRadius: number =
+        Math.min(Math.max(nbNeighbours + 1, 1), 2) * voltageLevelCircleRadius;
+    const unitaryRadius = vlCircleRadius / (nbNeighbours + 1);
+    return [
+        busIndex * unitaryRadius + interAnnulusSpace / 2,
+        (busIndex + 1) * unitaryRadius - interAnnulusSpace / 2,
+        vlCircleRadius,
+    ];
+}
+
+function getCirclePath(
+    radius: number,
+    angleStart: number,
+    angleEnd: number,
+    clockWise: boolean
+) {
+    const arcAngle = angleEnd - angleStart;
+    const xStart = radius * Math.cos(angleStart);
+    const yStart = radius * Math.sin(angleStart);
+    const xEnd = radius * Math.cos(angleEnd);
+    const yEnd = radius * Math.sin(angleEnd);
+    const largeArc = Math.abs(arcAngle) > Math.PI ? 1 : 0;
+    return (
+        xStart.toFixed(3) +
+        ',' +
+        yStart.toFixed(3) +
+        ' A' +
+        radius.toFixed(3) +
+        ',' +
+        radius.toFixed(3) +
+        ' ' +
+        radToDeg(arcAngle).toFixed(3) +
+        ' ' +
+        largeArc +
+        ' ' +
+        (clockWise ? 1 : 0) +
+        ' ' +
+        xEnd.toFixed(3) +
+        ',' +
+        yEnd.toFixed(3)
+    );
+}
+
+// get path for bus annulus
+export function getFragmentedAnnulusPath(
+    angles: number[],
+    busNodeRadius: [number, number, number],
+    nodeHollowWidth: number
+): string {
+    let path: string = '';
+    const halfWidth = nodeHollowWidth / 2;
+    const deltaAngle0 = halfWidth / busNodeRadius[1];
+    const deltaAngle1 = halfWidth / busNodeRadius[0];
+    for (let index = 0; index < angles.length; index++) {
+        const outerArcStart = angles[index] + deltaAngle0;
+        const outerArcEnd = angles[index + 1] - deltaAngle0;
+        const innerArcStart = angles[index + 1] - deltaAngle1;
+        const innerArcEnd = angles[index] + deltaAngle1;
+        if (outerArcEnd > outerArcStart && innerArcEnd < innerArcStart) {
+            path =
+                path +
+                'M' +
+                getCirclePath(
+                    busNodeRadius[1],
+                    outerArcStart,
+                    outerArcEnd,
+                    true
+                ) +
+                ' L' +
+                getCirclePath(
+                    busNodeRadius[0],
+                    innerArcStart,
+                    innerArcEnd,
+                    false
+                ) +
+                ' Z ';
+        }
+    }
+    return path;
+}
+
+function getPolylinePoints(polylinePoints: string): Point[] | null {
+    const coordinates: string[] = polylinePoints.split(/,| /);
+    if (coordinates.length < 4) {
+        return null;
+    }
+    const points: Point[] = [];
+    for (let index = 0; index < 4; index = index + 2) {
+        const point = new Point(+coordinates[index], +coordinates[index + 1]);
+        points.push(point);
+    }
+    return points;
+}
+
+// get angle of first 2 points of a polyline
+export function getPolylineAngle(polylinePoints: string): number | null {
+    const points: Point[] | null = getPolylinePoints(polylinePoints);
+    if (points == null) {
+        return null;
+    }
+    return getAngle(points[0], points[1]);
+}
+
+function getPathPoints(pathPoints: string): Point[] | null {
+    const stringPoints: string[] = pathPoints.split(' ');
+    if (stringPoints.length < 2) {
+        return null;
+    }
+    const points: Point[] = [];
+    for (let index = 0; index < 2; index++) {
+        const coordinates: string[] = stringPoints[index]
+            .substring(1)
+            .split(',');
+        const point = new Point(+coordinates[0], +coordinates[1]);
+        points.push(point);
+    }
+    return points;
+}
+
+// get angle of first 2 points of a path
+export function getPathAngle(pathPoints: string): number | null {
+    const points: Point[] | null = getPathPoints(pathPoints);
+    if (points == null) {
+        return null;
+    }
+    return getAngle(points[0], points[1]);
+}

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -345,7 +345,14 @@ function getPolylinePoints(polylinePoints: string): Point[] | null {
 }
 
 // get angle of first 2 points of a polyline
-export function getPolylineAngle(polylinePoints: string): number | null {
+export function getPolylineAngle(polyline: HTMLElement): number | null {
+    if (polyline.tagName !== 'polyline') {
+        return null;
+    }
+    const polylinePoints = polyline.getAttribute('points');
+    if (polylinePoints == null) {
+        return null;
+    }
     const points: Point[] | null = getPolylinePoints(polylinePoints);
     if (points == null) {
         return null;
@@ -370,10 +377,31 @@ function getPathPoints(pathPoints: string): Point[] | null {
 }
 
 // get angle of first 2 points of a path
-export function getPathAngle(pathPoints: string): number | null {
+export function getPathAngle(path: HTMLElement): number | null {
+    if (path.tagName !== 'path') {
+        return null;
+    }
+    const pathPoints = path.getAttribute('d');
+    if (pathPoints == null) {
+        return null;
+    }
     const points: Point[] | null = getPathPoints(pathPoints);
     if (points == null) {
         return null;
     }
     return getAngle(points[0], points[1]);
+}
+
+// sort list of bus nodes by index
+export function getSortedBusNodes(
+    busNodes: NodeListOf<SVGGraphicsElement>
+): SVGGraphicsElement[] {
+    const sortedBusNodes: SVGGraphicsElement[] = [];
+    busNodes.forEach((busNode) => {
+        const index = busNode.getAttribute('index') ?? '-1';
+        if (+index >= 0) {
+            sortedBusNodes[+index] = busNode;
+        }
+    });
+    return sortedBusNodes;
 }

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -849,25 +849,6 @@ export class NetworkAreaDiagramViewer {
         });
     }
 
-    private storeHalfEdgeAngle(
-        edgeNode: SVGGraphicsElement,
-        angleId: string,
-        sideIndex: number,
-        getAngle: (a: HTMLElement) => number | null
-    ) {
-        if (!this.edgeAngles.has(angleId)) {
-            const halfEdge: HTMLElement = <HTMLElement>(
-                edgeNode.children.item(sideIndex)?.firstElementChild
-            );
-            if (halfEdge != null) {
-                const angle = getAngle(halfEdge);
-                if (angle != null) {
-                    this.edgeAngles.set(angleId, angle);
-                }
-            }
-        }
-    }
-
     private redrawVoltageLevelNode(
         node: SVGGraphicsElement | null,
         busNodeEdges: Map<string, SVGGraphicsElement[]>,
@@ -952,14 +933,17 @@ export class NetworkAreaDiagramViewer {
                 this.container.querySelector("[id='" + edgeId + "']");
             if (edgeNode) {
                 const side = busId == busNode1 ? 0 : 1;
-                this.storeHalfEdgeAngle(
-                    edgeNode,
-                    angleId,
-                    side,
-                    isLoopEdge
-                        ? DiagramUtils.getPathAngle
-                        : DiagramUtils.getPolylineAngle
+                const halfEdge: HTMLElement = <HTMLElement>(
+                    edgeNode.children.item(side)?.firstElementChild
                 );
+                if (halfEdge != null) {
+                    const angle = isLoopEdge
+                        ? DiagramUtils.getPathAngle(halfEdge)
+                        : DiagramUtils.getPolylineAngle(halfEdge);
+                    if (angle != null) {
+                        this.edgeAngles.set(angleId, angle);
+                    }
+                }
             }
         }
         return this.edgeAngles.get(angleId);

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -426,7 +426,7 @@ export class NetworkAreaDiagramViewer {
 
     private getNodeRadius(busNodeId: number): [number, number, number] {
         const busNode: SVGGraphicsElement | null = this.container.querySelector(
-            'nad\\:busNode[svgId="' + busNodeId + '"]'
+            'nad\\:busnode[svgid="' + busNodeId + '"]'
         );
         const nbNeighbours = busNode?.getAttribute('nbneighbours');
         const busIndex = busNode?.getAttribute('index');
@@ -912,7 +912,7 @@ export class NetworkAreaDiagramViewer {
             // get buses belonging to voltage level
             const busNodes: NodeListOf<SVGGraphicsElement> =
                 this.container.querySelectorAll(
-                    'nad\\:busNode[vlNode="' + node.id + '"]'
+                    'nad\\:busnode[vlnode="' + node.id + '"]'
                 );
             // if single bus voltage level -> do not redraw anything
             if (busNodes.length <= 1) {

--- a/src/components/network-area-diagram-viewer/svg-parameters.ts
+++ b/src/components/network-area-diagram-viewer/svg-parameters.ts
@@ -8,16 +8,22 @@
 export class SvgParameters {
     // the SVG parameters values are now hardcoded in this class
     // the idea is to read them from the metadata included in the SVG
-    busAnnulusOuterRadius = 27.5;
+    voltageLevelCircleRadius = 30.0;
+    interAnnulusSpace = 5.0;
     transfomerCircleRadius = 20;
     edgeForkAperture = 60;
     edgeForkLength = 80.0;
     arrowShift = 30.0;
     arrowLabelShift = 19.0;
-    converterStationWidth = 70;
+    converterStationWidth = 70.0;
+    nodeHollowWidth = 15.0;
 
-    public getBusAnnulusOuterRadius(): number {
-        return this.busAnnulusOuterRadius;
+    public getVoltageLevelCircleRadius(): number {
+        return this.voltageLevelCircleRadius;
+    }
+
+    public getInterAnnulusSpace(): number {
+        return this.interAnnulusSpace;
     }
 
     public getTransfomerCircleRadius(): number {
@@ -42,5 +48,9 @@ export class SvgParameters {
 
     public getConverterStationWidth(): number {
         return this.converterStationWidth;
+    }
+
+    public getNodeHollowWidth(): number {
+        return this.nodeHollowWidth;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
feature


**What is the current behavior?**
The voltage levels with multiple buses are not correctly moved


**What is the new behavior (if this is a feature change)?**
The voltage levels with multiple buses can be moved, with correct computation of edges start positions, arrow position, and a possible redrawing of buses


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No