### PR TITLE
Fix node moving when zooming out after node selection in network area diagram

### DIFF
--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -244,6 +244,7 @@ export class NetworkAreaDiagramViewer {
     private drag(event: Event) {
         if (this.selectedElement) {
             event.preventDefault();
+            this.ctm = this.svgDraw?.node.getScreenCTM();
             this.updateGraph(event);
             this.initialPosition = DiagramUtils.getPosition(
                 this.selectedElement


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
In network area diagram, when zooming out after node selection, the selected node moves but it is far from the mouse position


**What is the new behavior (if this is a feature change)?**
In network area diagram, when zooming out after node selection, the moved node position corresponds with the mouse position


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No