### PR TITLE
Update metadata and add callback for node moving in network area diagram

### DIFF
--- a/demo/src/diagram-viewers/add-diagrams.js
+++ b/demo/src/diagram-viewers/add-diagrams.js
@@ -29,7 +29,8 @@ export const addNadToDemo = () => {
                 500,
                 600,
                 1000,
-                1200
+                1200,
+                handleNodeMove
             );
 
             document
@@ -47,7 +48,8 @@ export const addNadToDemo = () => {
                 500,
                 600,
                 1000,
-                1200
+                1200,
+                handleNodeMove
             );
 
             document
@@ -65,7 +67,8 @@ export const addNadToDemo = () => {
                 500,
                 600,
                 1000,
-                1200
+                1200,
+                handleNodeMove
             );
 
             document
@@ -83,7 +86,8 @@ export const addNadToDemo = () => {
                 500,
                 600,
                 1000,
-                1200
+                1200,
+                handleNodeMove
             );
 
             document
@@ -101,7 +105,8 @@ export const addNadToDemo = () => {
                 500,
                 600,
                 1000,
-                1200
+                1200,
+                handleNodeMove
             );
 
             document
@@ -119,7 +124,8 @@ export const addNadToDemo = () => {
                 500,
                 600,
                 1000,
-                1200
+                1200,
+                handleNodeMove
             );
 
             document
@@ -260,4 +266,22 @@ const handleTogglePopover = (
             equipmentType;
         console.log(msg);
     }
+};
+
+const handleNodeMove = (equipmentId, nodeId, x, y, xOrig, yOrig) => {
+    const msg =
+        'Node ' +
+        nodeId +
+        ' equipment ' +
+        equipmentId +
+        ' moved from [' +
+        xOrig +
+        ', ' +
+        yOrig +
+        '] to [' +
+        x +
+        ', ' +
+        y +
+        ']';
+    console.log(msg);
 };

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -27,6 +27,35 @@ const EdgeTypeMapping: { [key: string]: EdgeType } = {
     ThreeWtEdge: EdgeType.THREE_WINDINGS_TRANSFORMER,
 };
 
+// riound a number w.r.t a precision
+export function round(value: number, precision: number): number {
+    return +value.toFixed(precision);
+}
+
+// format number to string
+export function getFormattedValue(value: number): string {
+    return value.toFixed(2);
+}
+
+// format point to string
+export function getFormattedPoint(point: Point): string {
+    return getFormattedValue(point.x) + ',' + getFormattedValue(point.y);
+}
+
+// format points to polyline string
+export function getFormattedPolyline(
+    startPolyline: Point,
+    middlePolyline: Point | null,
+    endPolyline: Point
+): string {
+    let polyline: string = getFormattedPoint(startPolyline);
+    if (middlePolyline != null) {
+        polyline += ' ' + getFormattedPoint(middlePolyline);
+    }
+    polyline += ' ' + getFormattedPoint(endPolyline);
+    return polyline;
+}
+
 // transform angle degrees to radians
 export function degToRad(deg: number): number {
     return deg * (Math.PI / 180.0);
@@ -160,7 +189,7 @@ export function getTransformerArrowMatrixString(
         transformerCenter,
         transfomerCircleRadius
     );
-    return matrix.map((e) => e.toFixed(2)).join(',');
+    return matrix.map((e) => getFormattedValue(e)).join(',');
 }
 
 // get the points of a converter station of an HVDC line edge
@@ -200,15 +229,8 @@ export function getConverterStationPolyline(
         endPolyline2,
         converterStationWidth
     );
-    return (
-        points[0].x.toFixed(2) +
-        ',' +
-        points[0].y.toFixed(2) +
-        ' ' +
-        points[1].x.toFixed(2) +
-        ',' +
-        points[1].y.toFixed(2)
-    );
+    //return getFormattedPoint(points[0]) + ' ' + getFormattedPoint(points[1]);
+    return getFormattedPolyline(points[0], null, points[1]);
 }
 
 // get the drabbable element, if present,

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -27,11 +27,6 @@ const EdgeTypeMapping: { [key: string]: EdgeType } = {
     ThreeWtEdge: EdgeType.THREE_WINDINGS_TRANSFORMER,
 };
 
-// round a number w.r.t a precision
-export function round(value: number, precision: number): number {
-    return +value.toFixed(precision);
-}
-
 // format number to string
 export function getFormattedValue(value: number): string {
     return value.toFixed(2);

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -27,7 +27,7 @@ const EdgeTypeMapping: { [key: string]: EdgeType } = {
     ThreeWtEdge: EdgeType.THREE_WINDINGS_TRANSFORMER,
 };
 
-// riound a number w.r.t a precision
+// round a number w.r.t a precision
 export function round(value: number, precision: number): number {
     return +value.toFixed(precision);
 }
@@ -229,7 +229,6 @@ export function getConverterStationPolyline(
         endPolyline2,
         converterStationWidth
     );
-    //return getFormattedPoint(points[0]) + ' ' + getFormattedPoint(points[1]);
     return getFormattedPolyline(points[0], null, points[1]);
 }
 

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.test.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.test.ts
@@ -18,7 +18,8 @@ describe('Test network-area-diagram-viewer.ts', () => {
             0,
             0,
             0,
-            0
+            0,
+            null
         );
 
         expect(container.getElementsByTagName('svg').length).toBe(0);

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -1211,30 +1211,27 @@ export class NetworkAreaDiagramViewer {
     }
 
     private updateMetadataCallCallback(mousePosition: Point) {
-        // get move node in metadata
+        // get moved node in metadata
         const node: SVGGraphicsElement | null = this.container.querySelector(
             'nad\\:node[svgid="' + this.selectedElement?.id + '"]'
         );
         if (node != null) {
+            // get new position
+            const xNew = DiagramUtils.getFormattedValue(mousePosition.x);
+            const yNew = DiagramUtils.getFormattedValue(mousePosition.y);
             // save original position, for the callback
-            const xOrig = node.getAttribute('x') ?? 0;
-            const yOrig = node.getAttribute('y') ?? 0;
+            const xOrig = node.getAttribute('x') ?? '0';
+            const yOrig = node.getAttribute('y') ?? '0';
             // update node position in metadata
-            node.setAttribute(
-                'x',
-                DiagramUtils.getFormattedValue(mousePosition.x)
-            );
-            node.setAttribute(
-                'y',
-                DiagramUtils.getFormattedValue(mousePosition.y)
-            );
+            node.setAttribute('x', xNew);
+            node.setAttribute('y', yNew);
             // call the callback, if defined
             if (this.onNodeCallback != null) {
                 this.onNodeCallback(
                     node.getAttribute('equipmentid') ?? '',
                     node.getAttribute('svgid') ?? '',
-                    DiagramUtils.round(mousePosition.x, 2),
-                    DiagramUtils.round(mousePosition.y, 2),
+                    +xNew,
+                    +yNew,
                     +xOrig,
                     +yOrig
                 );


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
feature


**What is the current behavior?**
When a node is moved in network area diagram the metadata of the node is not changed, and no callback is available for having information about the node moving


**What is the new behavior (if this is a feature change)?**
When a node is moved the metadata of the node is updated with the new position, and a callback has been added for having information about the node moving


**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [X] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
the constructor of the NetworkAreaDiagramViewer has a new additional parameter: the callback.
An example of callback is provided in the demo/src/diagram-viewers/add-diagrams.js file