### PR TITLE
Move edge names when moving edges in network area diagram

### DIFF
--- a/demo/src/diagram-viewers/data/nad-eurostag-tutorial-example1.svg
+++ b/demo/src/diagram-viewers/data/nad-eurostag-tutorial-example1.svg
@@ -176,6 +176,9 @@
             <g class="nad-glued-center">
                 <circle class="nad-vl0to30-line nad-winding" cx="-354.51" cy="-128.15" r="20.00"/>
                 <circle class="nad-vl300to500-line nad-winding" cx="-343.35" cy="-111.56" r="20.00"/>
+                <g class="nad-edge-label" transform="translate(-348.93,-119.86)">
+                    <text transform="rotate(56.08)" x="0.00" style="text-anchor:middle">NGEN_NHV1</text>
+                </g>
             </g>
         </g>
         <g id="9">
@@ -203,6 +206,11 @@
                     </g>
                 </g>
             </g>
+            <g class="nad-glued-center">
+                <g class="nad-edge-label" transform="translate(-54.98,86.38)">
+                    <text transform="rotate(3.61)" x="0.00" style="text-anchor:middle">NHV1_NHV2_1</text>
+                </g>
+            </g>
         </g>
         <g id="10">
             <g id="10.1" class="nad-vl300to500-line">
@@ -227,6 +235,11 @@
                         </g>
                         <text transform="rotate(-356.39)" x="-19.00" style="text-anchor:end">-300</text>
                     </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-edge-label" transform="translate(-49.95,6.53)">
+                    <text transform="rotate(3.61)" x="0.00" style="text-anchor:middle">NHV1_NHV2_2</text>
                 </g>
             </g>
         </g>
@@ -258,6 +271,9 @@
             <g class="nad-glued-center">
                 <circle class="nad-vl300to500-line nad-winding" cx="277.81" cy="-51.47" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="293.43" cy="-63.97" r="20.00"/>
+                <g class="nad-edge-label" transform="translate(285.62,-57.72)">
+                    <text transform="rotate(-38.68)" x="0.00" style="text-anchor:middle">NHV2_NLOAD</text>
+                </g>
             </g>
         </g>
     </g>

--- a/demo/src/diagram-viewers/data/nad-scada.svg
+++ b/demo/src/diagram-viewers/data/nad-scada.svg
@@ -176,6 +176,11 @@
                     </g>
                 </g>
             </g>
+            <g class="nad-glued-center">
+                <g class="nad-edge-label" transform="translate(7.93,87.69)">
+                    <text transform="rotate(-1.33)" x="0.00" style="text-anchor:middle">line</text>
+                </g>
+            </g>
         </g>
         <g id="6">
             <g id="6.1" class="nad-vl300to500-line">
@@ -206,6 +211,9 @@
                 <circle class="nad-vl300to500-line nad-winding" cx="18.86" cy="127.44" r="20.00"/>
                 <circle class="nad-vl180to300-line nad-winding" cx="-1.13" cy="127.91" r="20.00"/>
                 <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-1.00,0.02,-0.02,-1.00,39.55,156.97)" class="nad-pst-arrow"/>
+                <g class="nad-edge-label" transform="translate(8.86,127.68)">
+                    <text transform="rotate(-1.33)" x="0.00" style="text-anchor:middle">tw2t</text>
+                </g>
             </g>
         </g>
         <g id="13" class="nad-dangling-line-edge">
@@ -252,6 +260,9 @@
             </g>
             <g class="nad-glued-center">
                 <polyline points="44.78,166.85 -25.20,168.48" class="nad-hvdc"/>
+                <g class="nad-edge-label" transform="translate(9.79,167.67)">
+                    <text transform="rotate(-1.33)" x="0.00" style="text-anchor:middle">hvdcline</text>
+                </g>
             </g>
         </g>
     </g>

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -437,44 +437,6 @@ export function getBoundarySemicircle(
     );
 }
 
-// get egde name elements: position and angle elements
-export function getEdgeNameElements(
-    edgeNode: SVGGraphicsElement
-): [SVGGraphicsElement | null, SVGGraphicsElement | null] {
-    let edgeNamePositionElement: SVGGraphicsElement | null = null;
-    let edgeNameAngleElement: SVGGraphicsElement | null = null;
-    // get DOM element containing name
-    const nameElement: SVGGraphicsElement =
-        edgeNode.lastElementChild as SVGGraphicsElement;
-    if (
-        nameElement != null &&
-        nameElement.tagName == 'g' &&
-        (nameElement.id == null || nameElement.id.length == 0)
-    ) {
-        // get DOM element containing name position
-        const namePositionElement: SVGGraphicsElement =
-            nameElement.lastElementChild as SVGGraphicsElement;
-        if (
-            namePositionElement != null &&
-            namePositionElement.tagName == 'g' &&
-            (namePositionElement.id == null ||
-                namePositionElement.id.length == 0)
-        ) {
-            edgeNamePositionElement = namePositionElement;
-            // get DOM element containing name angle
-            const nameAngleElement: SVGGraphicsElement =
-                namePositionElement.lastElementChild as SVGGraphicsElement;
-            if (
-                nameAngleElement != null &&
-                nameAngleElement.tagName == 'text'
-            ) {
-                edgeNameAngleElement = nameAngleElement;
-            }
-        }
-    }
-    return [edgeNamePositionElement, edgeNameAngleElement];
-}
-
 // get the angle of a edge name between two points
 export function getEdgeNameAngle(point1: Point, point2: Point): number {
     const angle = getAngle(point1, point2);

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -436,3 +436,48 @@ export function getBoundarySemicircle(
         getCirclePath(busOuterRadius, startAngle, startAngle + Math.PI, true)
     );
 }
+
+// get egde name elements: position and angle elements
+export function getEdgeNameElements(
+    edgeNode: SVGGraphicsElement
+): [SVGGraphicsElement | null, SVGGraphicsElement | null] {
+    let edgeNamePositionElement: SVGGraphicsElement | null = null;
+    let edgeNameAngleElement: SVGGraphicsElement | null = null;
+    // get DOM element containing name
+    const nameElement: SVGGraphicsElement =
+        edgeNode.lastElementChild as SVGGraphicsElement;
+    if (
+        nameElement != null &&
+        nameElement.tagName == 'g' &&
+        (nameElement.id == null || nameElement.id.length == 0)
+    ) {
+        // get DOM element containing name position
+        const namePositionElement: SVGGraphicsElement =
+            nameElement.lastElementChild as SVGGraphicsElement;
+        if (
+            namePositionElement != null &&
+            namePositionElement.tagName == 'g' &&
+            (namePositionElement.id == null ||
+                namePositionElement.id.length == 0)
+        ) {
+            edgeNamePositionElement = namePositionElement;
+            // get DOM element containing name angle
+            const nameAngleElement: SVGGraphicsElement =
+                namePositionElement.lastElementChild as SVGGraphicsElement;
+            if (
+                nameAngleElement != null &&
+                nameAngleElement.tagName == 'text'
+            ) {
+                edgeNameAngleElement = nameAngleElement;
+            }
+        }
+    }
+    return [edgeNamePositionElement, edgeNameAngleElement];
+}
+
+// get the angle of a edge name between two points
+export function getEdgeNameAngle(point1: Point, point2: Point): number {
+    const angle = getAngle(point1, point2);
+    const textFlipped = Math.cos(angle) < 0;
+    return radToDeg(textFlipped ? angle - Math.PI : angle);
+}

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -731,6 +731,14 @@ export class NetworkAreaDiagramViewer {
                 edgeMiddle
             );
         }
+        // if present, move edge name
+        if (this.svgParameters.getEdgeNameDisplayed()) {
+            this.moveEdgeName(
+                edgeNode,
+                edgeMiddle,
+                edgeFork1 == null ? edgeStart1 : edgeFork1
+            );
+        }
         // store edge angles, to use them for bus node redrawing
         this.edgeAngles.set(
             edgeNode.id + '.1',
@@ -958,6 +966,36 @@ export class NetworkAreaDiagramViewer {
             }
             this.moveSvgElement(edgeId, this.getTranslation(mousePosition));
         });
+    }
+
+    moveEdgeName(
+        edgeNode: SVGGraphicsElement,
+        anchorPoint: Point,
+        edgeStart: Point
+    ) {
+        const edgeNameElements = DiagramUtils.getEdgeNameElements(edgeNode);
+        const positionElement: SVGGraphicsElement | null = edgeNameElements[0];
+        if (positionElement != null) {
+            // move edge name position
+            positionElement.setAttribute(
+                'transform',
+                'translate(' + DiagramUtils.getFormattedPoint(anchorPoint) + ')'
+            );
+            const angleElement: SVGGraphicsElement | null = edgeNameElements[1];
+            if (angleElement != null) {
+                // change edge name angle
+                const edgeNameAngle = DiagramUtils.getEdgeNameAngle(
+                    edgeStart,
+                    anchorPoint
+                );
+                angleElement.setAttribute(
+                    'transform',
+                    'rotate(' +
+                        DiagramUtils.getFormattedValue(edgeNameAngle) +
+                        ')'
+                );
+            }
+        }
     }
 
     private redrawVoltageLevelNode(

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -973,15 +973,16 @@ export class NetworkAreaDiagramViewer {
         anchorPoint: Point,
         edgeStart: Point
     ) {
-        const edgeNameElements = DiagramUtils.getEdgeNameElements(edgeNode);
-        const positionElement: SVGGraphicsElement | null = edgeNameElements[0];
+        const positionElement: SVGGraphicsElement | null =
+            edgeNode.querySelector('.nad-edge-label') as SVGGraphicsElement;
         if (positionElement != null) {
             // move edge name position
             positionElement.setAttribute(
                 'transform',
                 'translate(' + DiagramUtils.getFormattedPoint(anchorPoint) + ')'
             );
-            const angleElement: SVGGraphicsElement | null = edgeNameElements[1];
+            const angleElement: SVGGraphicsElement | null =
+                positionElement.querySelector('text') as SVGGraphicsElement;
             if (angleElement != null) {
                 // change edge name angle
                 const edgeNameAngle = DiagramUtils.getEdgeNameAngle(

--- a/src/components/network-area-diagram-viewer/svg-parameters.ts
+++ b/src/components/network-area-diagram-viewer/svg-parameters.ts
@@ -18,6 +18,7 @@ export class SvgParameters {
     converterStationWidth = 70.0;
     nodeHollowWidth = 15.0;
     unknownBusNodeExtraRadius = 10.0;
+    edgeNameDisplayed = true;
 
     public getVoltageLevelCircleRadius(): number {
         return this.voltageLevelCircleRadius;
@@ -57,5 +58,9 @@ export class SvgParameters {
 
     public getUnknownBusNodeExtraRadius(): number {
         return this.unknownBusNodeExtraRadius;
+    }
+
+    public getEdgeNameDisplayed(): boolean {
+        return this.edgeNameDisplayed;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
In network area diagram, when moving an edge (due to the movement of a voltage level node) the edge name, if displayed, is not moved


**What is the new behavior (if this is a feature change)?**
When moving an edge (following the movement of a voltage level node) the edge name is correctly moved


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No
