### PR TITLE
Read SVG parameters from metadata in network area diagram

### DIFF
--- a/demo/src/diagram-viewers/data/nad-eurostag-tutorial-example1.svg
+++ b/demo/src/diagram-viewers/data/nad-eurostag-tutorial-example1.svg
@@ -131,6 +131,7 @@
                 <nad:edge svgId="10" equipmentId="NHV1_NHV2_2" node1="2" node2="4" busNode1="3" busNode2="5" type="LineEdge"/>
                 <nad:edge svgId="11" equipmentId="NHV2_NLOAD" node1="4" node2="6" busNode1="5" busNode2="7" type="TwoWtEdge"/>
             </nad:edges>
+            <nad:svgParameters insertNameDesc="false" svgWidthAndHeightAdded="false" cssLocation="INSERTED_IN_SVG" sizeConstraint="FIXED_SCALE" fixedWidth="-1" fixedHeight="-1" fixedScale="0.2" arrowShift="30.00" arrowLabelShift="19.00" converterStationWidth="70.00" voltageLevelCircleRadius="30.00" fictitiousVoltageLevelCircleRadius="15.00" transformerCircleRadius="20.00" nodeHollowWidth="15.00" edgesForkLength="80.00" edgesForkAperture="1.05" edgeStartShift="0.00" unknownBusNodeExtraRadius="10.00" loopDistance="120.00" loopEdgesAperture="1.05" loopControlDistance="40.00" edgeInfoAlongEdge="true" edgeNameDisplayed="true" interAnnulusSpace="5.00" svgPrefix="" idDisplayed="false" substationDescriptionDisplayed="false" arrowHeight="10.00" busLegend="true" voltageLevelDetails="false" detailedTextNodeYShift="25.00" languageTag="en" voltageValuePrecision="1" powerValuePrecision="0" angleValuePrecision="1" currentValuePrecision="0" edgeInfoDisplayed="ACTIVE_POWER" pstArrowHeadSize="8.00" undefinedValueSymbol=""/>
         </nad:nad>
     </metadata>
     <g class="nad-vl-nodes">

--- a/demo/src/diagram-viewers/data/nad-eurostag-tutorial-example1.svg
+++ b/demo/src/diagram-viewers/data/nad-eurostag-tutorial-example1.svg
@@ -176,6 +176,9 @@
             <g class="nad-glued-center">
                 <circle class="nad-vl0to30-line nad-winding" cx="-354.51" cy="-128.15" r="20.00"/>
                 <circle class="nad-vl300to500-line nad-winding" cx="-343.35" cy="-111.56" r="20.00"/>
+                <g class="nad-edge-label" transform="translate(-348.93,-119.86)">
+                    <text transform="rotate(56.08)" x="0.00" style="text-anchor:middle">NGEN_NHV1</text>
+                </g>
             </g>
         </g>
         <g id="9">
@@ -203,6 +206,11 @@
                     </g>
                 </g>
             </g>
+            <g class="nad-glued-center">
+                <g class="nad-edge-label" transform="translate(-54.98,86.38)">
+                    <text transform="rotate(3.61)" x="0.00" style="text-anchor:middle">NHV1_NHV2_1</text>
+                </g>
+            </g>
         </g>
         <g id="10">
             <g id="10.1" class="nad-vl300to500-line">
@@ -227,6 +235,11 @@
                         </g>
                         <text transform="rotate(-356.39)" x="-19.00" style="text-anchor:end">-300</text>
                     </g>
+                </g>
+            </g>
+            <g class="nad-glued-center">
+                <g class="nad-edge-label" transform="translate(-49.95,6.53)">
+                    <text transform="rotate(3.61)" x="0.00" style="text-anchor:middle">NHV1_NHV2_2</text>
                 </g>
             </g>
         </g>
@@ -258,6 +271,9 @@
             <g class="nad-glued-center">
                 <circle class="nad-vl300to500-line nad-winding" cx="277.81" cy="-51.47" r="20.00"/>
                 <circle class="nad-vl120to180-line nad-winding" cx="293.43" cy="-63.97" r="20.00"/>
+                <g class="nad-edge-label" transform="translate(285.62,-57.72)">
+                    <text transform="rotate(-38.68)" x="0.00" style="text-anchor:middle">NHV2_NLOAD</text>
+                </g>
             </g>
         </g>
     </g>

--- a/demo/src/diagram-viewers/data/nad-four-substations.svg
+++ b/demo/src/diagram-viewers/data/nad-four-substations.svg
@@ -134,6 +134,7 @@
                 <nad:edge svgId="13" equipmentId="LINE_S2S3" node1="4" node2="6" busNode1="5" busNode2="7" type="LineEdge"/>
                 <nad:edge svgId="14" equipmentId="LINE_S3S4" node1="6" node2="8" busNode1="7" busNode2="9" type="LineEdge"/>
             </nad:edges>
+            <nad:svgParameters insertNameDesc="false" svgWidthAndHeightAdded="false" cssLocation="INSERTED_IN_SVG" sizeConstraint="FIXED_SCALE" fixedWidth="-1" fixedHeight="-1" fixedScale="0.2" arrowShift="30.00" arrowLabelShift="19.00" converterStationWidth="70.00" voltageLevelCircleRadius="30.00" fictitiousVoltageLevelCircleRadius="15.00" transformerCircleRadius="20.00" nodeHollowWidth="15.00" edgesForkLength="80.00" edgesForkAperture="1.05" edgeStartShift="0.00" unknownBusNodeExtraRadius="10.00" loopDistance="120.00" loopEdgesAperture="1.05" loopControlDistance="40.00" edgeInfoAlongEdge="true" edgeNameDisplayed="false" interAnnulusSpace="5.00" svgPrefix="" idDisplayed="false" substationDescriptionDisplayed="false" arrowHeight="10.00" busLegend="true" voltageLevelDetails="false" detailedTextNodeYShift="25.00" languageTag="en" voltageValuePrecision="1" powerValuePrecision="0" angleValuePrecision="1" currentValuePrecision="0" edgeInfoDisplayed="ACTIVE_POWER" pstArrowHeadSize="8.00" undefinedValueSymbol=""/>
         </nad:nad>
     </metadata>
     <g class="nad-vl-nodes">

--- a/demo/src/diagram-viewers/data/nad-ieee14cdf-solved.svg
+++ b/demo/src/diagram-viewers/data/nad-ieee14cdf-solved.svg
@@ -164,6 +164,7 @@
                 <nad:edge svgId="43" equipmentId="T4-9-1" node1="16" node2="16" busNode1="17" busNode2="19" type="TwoWtEdge"/>
                 <nad:edge svgId="44" equipmentId="T5-6-1" node1="20" node2="20" busNode1="21" busNode2="22" type="TwoWtEdge"/>
             </nad:edges>
+            <nad:svgParameters insertNameDesc="false" svgWidthAndHeightAdded="false" cssLocation="INSERTED_IN_SVG" sizeConstraint="FIXED_SCALE" fixedWidth="-1" fixedHeight="-1" fixedScale="0.2" arrowShift="30.00" arrowLabelShift="19.00" converterStationWidth="70.00" voltageLevelCircleRadius="30.00" fictitiousVoltageLevelCircleRadius="15.00" transformerCircleRadius="20.00" nodeHollowWidth="15.00" edgesForkLength="80.00" edgesForkAperture="1.05" edgeStartShift="0.00" unknownBusNodeExtraRadius="10.00" loopDistance="120.00" loopEdgesAperture="1.05" loopControlDistance="40.00" edgeInfoAlongEdge="true" edgeNameDisplayed="false" interAnnulusSpace="5.00" svgPrefix="" idDisplayed="false" substationDescriptionDisplayed="false" arrowHeight="10.00" busLegend="true" voltageLevelDetails="false" detailedTextNodeYShift="25.00" languageTag="en" voltageValuePrecision="1" powerValuePrecision="0" angleValuePrecision="1" currentValuePrecision="0" edgeInfoDisplayed="ACTIVE_POWER" pstArrowHeadSize="8.00" undefinedValueSymbol=""/>
         </nad:nad>
     </metadata>
     <g class="nad-vl-nodes">

--- a/demo/src/diagram-viewers/data/nad-ieee300cdf-VL9006.svg
+++ b/demo/src/diagram-viewers/data/nad-ieee300cdf-VL9006.svg
@@ -200,6 +200,7 @@
                 <nad:edge svgId="79" equipmentId="T9007-9071-1" node1="10" node2="47" busNode1="11" busNode2="48" type="TwoWtEdge"/>
                 <nad:edge svgId="80" equipmentId="T9007-9072-1" node1="10" node2="47" busNode1="11" busNode2="49" type="TwoWtEdge"/>
             </nad:edges>
+            <nad:svgParameters insertNameDesc="false" svgWidthAndHeightAdded="false" cssLocation="INSERTED_IN_SVG" sizeConstraint="FIXED_SCALE" fixedWidth="-1" fixedHeight="-1" fixedScale="0.2" arrowShift="30.00" arrowLabelShift="19.00" converterStationWidth="70.00" voltageLevelCircleRadius="30.00" fictitiousVoltageLevelCircleRadius="15.00" transformerCircleRadius="20.00" nodeHollowWidth="15.00" edgesForkLength="80.00" edgesForkAperture="1.05" edgeStartShift="0.00" unknownBusNodeExtraRadius="10.00" loopDistance="120.00" loopEdgesAperture="1.05" loopControlDistance="40.00" edgeInfoAlongEdge="true" edgeNameDisplayed="false" interAnnulusSpace="5.00" svgPrefix="" idDisplayed="false" substationDescriptionDisplayed="false" arrowHeight="10.00" busLegend="true" voltageLevelDetails="false" detailedTextNodeYShift="25.00" languageTag="en" voltageValuePrecision="1" powerValuePrecision="0" angleValuePrecision="1" currentValuePrecision="0" edgeInfoDisplayed="ACTIVE_POWER" pstArrowHeadSize="8.00" undefinedValueSymbol=""/>
         </nad:nad>
     </metadata>
     <g class="nad-vl-nodes">

--- a/demo/src/diagram-viewers/data/nad-ieee9-zeroimpedance-cdf.svg
+++ b/demo/src/diagram-viewers/data/nad-ieee9-zeroimpedance-cdf.svg
@@ -142,6 +142,7 @@
                 <nad:edge svgId="21" equipmentId="L9-6-0" node1="7" node2="12" busNode1="9" busNode2="13" type="LineEdge"/>
                 <nad:edge svgId="22" equipmentId="T9-3-0" node1="7" node2="7" busNode1="9" busNode2="8" type="TwoWtEdge"/>
             </nad:edges>
+            <nad:svgParameters insertNameDesc="false" svgWidthAndHeightAdded="false" cssLocation="INSERTED_IN_SVG" sizeConstraint="FIXED_SCALE" fixedWidth="-1" fixedHeight="-1" fixedScale="0.2" arrowShift="30.00" arrowLabelShift="19.00" converterStationWidth="70.00" voltageLevelCircleRadius="30.00" fictitiousVoltageLevelCircleRadius="15.00" transformerCircleRadius="20.00" nodeHollowWidth="15.00" edgesForkLength="80.00" edgesForkAperture="1.05" edgeStartShift="0.00" unknownBusNodeExtraRadius="10.00" loopDistance="120.00" loopEdgesAperture="1.05" loopControlDistance="40.00" edgeInfoAlongEdge="true" edgeNameDisplayed="false" interAnnulusSpace="5.00" svgPrefix="" idDisplayed="false" substationDescriptionDisplayed="false" arrowHeight="10.00" busLegend="true" voltageLevelDetails="false" detailedTextNodeYShift="25.00" languageTag="en" voltageValuePrecision="1" powerValuePrecision="0" angleValuePrecision="1" currentValuePrecision="0" edgeInfoDisplayed="ACTIVE_POWER" pstArrowHeadSize="8.00" undefinedValueSymbol=""/>
         </nad:nad>
     </metadata>
     <g class="nad-vl-nodes">

--- a/demo/src/diagram-viewers/data/nad-scada.svg
+++ b/demo/src/diagram-viewers/data/nad-scada.svg
@@ -134,6 +134,7 @@
                 <nad:edge svgId="9" equipmentId="t3wt" node1="2" node2="7" busNode1="3" busNode2="7" type="ThreeWtEdge"/>
                 <nad:edge svgId="10" equipmentId="t3wt" node1="4" node2="7" busNode1="" busNode2="7" type="ThreeWtEdge"/>
             </nad:edges>
+            <nad:svgParameters insertNameDesc="false" svgWidthAndHeightAdded="false" cssLocation="INSERTED_IN_SVG" sizeConstraint="FIXED_SCALE" fixedWidth="-1" fixedHeight="-1" fixedScale="0.2" arrowShift="30.00" arrowLabelShift="19.00" converterStationWidth="70.00" voltageLevelCircleRadius="30.00" fictitiousVoltageLevelCircleRadius="15.00" transformerCircleRadius="20.00" nodeHollowWidth="15.00" edgesForkLength="80.00" edgesForkAperture="1.05" edgeStartShift="0.00" unknownBusNodeExtraRadius="10.00" loopDistance="120.00" loopEdgesAperture="1.05" loopControlDistance="40.00" edgeInfoAlongEdge="true" edgeNameDisplayed="true" interAnnulusSpace="5.00" svgPrefix="" idDisplayed="false" substationDescriptionDisplayed="false" arrowHeight="10.00" busLegend="true" voltageLevelDetails="false" detailedTextNodeYShift="25.00" languageTag="en" voltageValuePrecision="1" powerValuePrecision="0" angleValuePrecision="1" currentValuePrecision="0" edgeInfoDisplayed="ACTIVE_POWER" pstArrowHeadSize="8.00" undefinedValueSymbol=""/>
         </nad:nad>
     </metadata>
     <g class="nad-vl-nodes">

--- a/demo/src/diagram-viewers/data/nad-scada.svg
+++ b/demo/src/diagram-viewers/data/nad-scada.svg
@@ -176,6 +176,11 @@
                     </g>
                 </g>
             </g>
+            <g class="nad-glued-center">
+                <g class="nad-edge-label" transform="translate(7.93,87.69)">
+                    <text transform="rotate(-1.33)" x="0.00" style="text-anchor:middle">line</text>
+                </g>
+            </g>
         </g>
         <g id="6">
             <g id="6.1" class="nad-vl300to500-line">
@@ -206,6 +211,9 @@
                 <circle class="nad-vl300to500-line nad-winding" cx="18.86" cy="127.44" r="20.00"/>
                 <circle class="nad-vl180to300-line nad-winding" cx="-1.13" cy="127.91" r="20.00"/>
                 <path d="M60.00,0 0,60.00 M52.00,0 60.00,0 60.00,8.00" transform="matrix(-1.00,0.02,-0.02,-1.00,39.55,156.97)" class="nad-pst-arrow"/>
+                <g class="nad-edge-label" transform="translate(8.86,127.68)">
+                    <text transform="rotate(-1.33)" x="0.00" style="text-anchor:middle">tw2t</text>
+                </g>
             </g>
         </g>
         <g id="13" class="nad-dangling-line-edge">
@@ -252,6 +260,9 @@
             </g>
             <g class="nad-glued-center">
                 <polyline points="44.78,166.85 -25.20,168.48" class="nad-hvdc"/>
+                <g class="nad-edge-label" transform="translate(9.79,167.67)">
+                    <text transform="rotate(-1.33)" x="0.00" style="text-anchor:middle">hvdcline</text>
+                </g>
             </g>
         </g>
     </g>

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -437,44 +437,6 @@ export function getBoundarySemicircle(
     );
 }
 
-// get egde name elements: position and angle elements
-export function getEdgeNameElements(
-    edgeNode: SVGGraphicsElement
-): [SVGGraphicsElement | null, SVGGraphicsElement | null] {
-    let edgeNamePositionElement: SVGGraphicsElement | null = null;
-    let edgeNameAngleElement: SVGGraphicsElement | null = null;
-    // get DOM element containing name
-    const nameElement: SVGGraphicsElement =
-        edgeNode.lastElementChild as SVGGraphicsElement;
-    if (
-        nameElement != null &&
-        nameElement.tagName == 'g' &&
-        (nameElement.id == null || nameElement.id.length == 0)
-    ) {
-        // get DOM element containing name position
-        const namePositionElement: SVGGraphicsElement =
-            nameElement.lastElementChild as SVGGraphicsElement;
-        if (
-            namePositionElement != null &&
-            namePositionElement.tagName == 'g' &&
-            (namePositionElement.id == null ||
-                namePositionElement.id.length == 0)
-        ) {
-            edgeNamePositionElement = namePositionElement;
-            // get DOM element containing name angle
-            const nameAngleElement: SVGGraphicsElement =
-                namePositionElement.lastElementChild as SVGGraphicsElement;
-            if (
-                nameAngleElement != null &&
-                nameAngleElement.tagName == 'text'
-            ) {
-                edgeNameAngleElement = nameAngleElement;
-            }
-        }
-    }
-    return [edgeNamePositionElement, edgeNameAngleElement];
-}
-
 // get the angle of a edge name between two points
 export function getEdgeNameAngle(point1: Point, point2: Point): number {
     const angle = getAngle(point1, point2);

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -436,3 +436,48 @@ export function getBoundarySemicircle(
         getCirclePath(busOuterRadius, startAngle, startAngle + Math.PI, true)
     );
 }
+
+// get egde name elements: position and angle elements
+export function getEdgeNameElements(
+    edgeNode: SVGGraphicsElement
+): [SVGGraphicsElement | null, SVGGraphicsElement | null] {
+    let edgeNamePositionElement: SVGGraphicsElement | null = null;
+    let edgeNameAngleElement: SVGGraphicsElement | null = null;
+    // get DOM element containing name
+    const nameElement: SVGGraphicsElement =
+        edgeNode.lastElementChild as SVGGraphicsElement;
+    if (
+        nameElement != null &&
+        nameElement.tagName == 'g' &&
+        (nameElement.id == null || nameElement.id.length == 0)
+    ) {
+        // get DOM element containing name position
+        const namePositionElement: SVGGraphicsElement =
+            nameElement.lastElementChild as SVGGraphicsElement;
+        if (
+            namePositionElement != null &&
+            namePositionElement.tagName == 'g' &&
+            (namePositionElement.id == null ||
+                namePositionElement.id.length == 0)
+        ) {
+            edgeNamePositionElement = namePositionElement;
+            // get DOM element containing name angle
+            const nameAngleElement: SVGGraphicsElement =
+                namePositionElement.lastElementChild as SVGGraphicsElement;
+            if (
+                nameAngleElement != null &&
+                nameAngleElement.tagName == 'text'
+            ) {
+                edgeNameAngleElement = nameAngleElement;
+            }
+        }
+    }
+    return [edgeNamePositionElement, edgeNameAngleElement];
+}
+
+// get the angle of a edge name between two points
+export function getEdgeNameAngle(point1: Point, point2: Point): number {
+    const angle = getAngle(point1, point2);
+    const textFlipped = Math.cos(angle) < 0;
+    return radToDeg(textFlipped ? angle - Math.PI : angle);
+}

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -731,6 +731,14 @@ export class NetworkAreaDiagramViewer {
                 edgeMiddle
             );
         }
+        // if present, move edge name
+        if (this.svgParameters.getEdgeNameDisplayed()) {
+            this.moveEdgeName(
+                edgeNode,
+                edgeMiddle,
+                edgeFork1 == null ? edgeStart1 : edgeFork1
+            );
+        }
         // store edge angles, to use them for bus node redrawing
         this.edgeAngles.set(
             edgeNode.id + '.1',
@@ -958,6 +966,36 @@ export class NetworkAreaDiagramViewer {
             }
             this.moveSvgElement(edgeId, this.getTranslation(mousePosition));
         });
+    }
+
+    moveEdgeName(
+        edgeNode: SVGGraphicsElement,
+        anchorPoint: Point,
+        edgeStart: Point
+    ) {
+        const edgeNameElements = DiagramUtils.getEdgeNameElements(edgeNode);
+        const positionElement: SVGGraphicsElement | null = edgeNameElements[0];
+        if (positionElement != null) {
+            // move edge name position
+            positionElement.setAttribute(
+                'transform',
+                'translate(' + DiagramUtils.getFormattedPoint(anchorPoint) + ')'
+            );
+            const angleElement: SVGGraphicsElement | null = edgeNameElements[1];
+            if (angleElement != null) {
+                // change edge name angle
+                const edgeNameAngle = DiagramUtils.getEdgeNameAngle(
+                    edgeStart,
+                    anchorPoint
+                );
+                angleElement.setAttribute(
+                    'transform',
+                    'rotate(' +
+                        DiagramUtils.getFormattedValue(edgeNameAngle) +
+                        ')'
+                );
+            }
+        }
     }
 
     private redrawVoltageLevelNode(

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -55,10 +55,7 @@ export class NetworkAreaDiagramViewer {
         this.originalWidth = 0;
         this.originalHeight = 0;
         this.init(minWidth, minHeight, maxWidth, maxHeight);
-        // get the SVG parameters
-        // so far, they are hardcoded in the class
-        // the idea is to read them from the metadata included in the SVG
-        this.svgParameters = new SvgParameters();
+        this.svgParameters = this.getSvgParameters();
         this.onNodeCallback = onNodeCallback;
     }
 
@@ -236,6 +233,12 @@ export class NetworkAreaDiagramViewer {
         this.svgDraw?.panZoom({
             panning: false,
         });
+    }
+
+    private getSvgParameters(): SvgParameters {
+        const svgParametersElement: SVGGraphicsElement | null =
+            this.container.querySelector('nad\\:svgparameters');
+        return new SvgParameters(svgParametersElement);
     }
 
     private startDrag(event: Event) {
@@ -480,10 +483,7 @@ export class NetworkAreaDiagramViewer {
             const angle = DiagramUtils.getAngle(point1, point2);
             const nbForks = edges.length;
             const angleStep =
-                DiagramUtils.degToRad(
-                    this.svgParameters.getEdgeForkAperture()
-                ) /
-                (nbForks - 1);
+                this.svgParameters.getEdgesForkAperture() / (nbForks - 1);
             let i = 0;
             edges.forEach((edge) => {
                 if (2 * i + 1 == nbForks) {
@@ -512,21 +512,18 @@ export class NetworkAreaDiagramViewer {
                     }
                     // compute moved edge data: polyline points
                     const alpha =
-                        -DiagramUtils.degToRad(
-                            this.svgParameters.getEdgeForkAperture()
-                        ) /
-                            2 +
+                        -this.svgParameters.getEdgesForkAperture() / 2 +
                         i * angleStep;
                     const angleFork1 = angle - alpha;
                     const angleFork2 = angle + Math.PI + alpha;
                     const edgeFork1 = DiagramUtils.getEdgeFork(
                         point1,
-                        this.svgParameters.getEdgeForkLength(),
+                        this.svgParameters.getEdgesForkLength(),
                         angleFork1
                     );
                     const edgeFork2 = DiagramUtils.getEdgeFork(
                         point2,
-                        this.svgParameters.getEdgeForkLength(),
+                        this.svgParameters.getEdgesForkLength(),
                         angleFork2
                     );
                     const busNodeId1 = edge.getAttribute('busnode1');
@@ -777,7 +774,7 @@ export class NetworkAreaDiagramViewer {
             ? DiagramUtils.getPointAtDistance(
                   endPolyline,
                   middlePolyline == null ? startPolyline : middlePolyline,
-                  1.5 * this.svgParameters.getTransfomerCircleRadius()
+                  1.5 * this.svgParameters.getTransformerCircleRadius()
               )
             : endPolyline;
         const polylinePoints: string = DiagramUtils.getFormattedPolyline(
@@ -871,7 +868,7 @@ export class NetworkAreaDiagramViewer {
             DiagramUtils.getPointAtDistance(
                 endPolyline1,
                 startPolyline1,
-                1.5 * this.svgParameters.getTransfomerCircleRadius()
+                1.5 * this.svgParameters.getTransformerCircleRadius()
             )
         );
         this.moveTransformerCircle(
@@ -880,7 +877,7 @@ export class NetworkAreaDiagramViewer {
             DiagramUtils.getPointAtDistance(
                 endPolyline2,
                 startPolyline2,
-                1.5 * this.svgParameters.getTransfomerCircleRadius()
+                1.5 * this.svgParameters.getTransformerCircleRadius()
             )
         );
         // if phase shifting transformer move transformer arrow
@@ -904,7 +901,7 @@ export class NetworkAreaDiagramViewer {
         const circleCenter: Point = DiagramUtils.getPointAtDistance(
             endPolyline,
             startPolyline,
-            -this.svgParameters.getTransfomerCircleRadius()
+            -this.svgParameters.getTransformerCircleRadius()
         );
         transformerCircle.setAttribute(
             'cx',
@@ -928,7 +925,7 @@ export class NetworkAreaDiagramViewer {
             startPolyline,
             endPolyline,
             transformerCenter,
-            this.svgParameters.getTransfomerCircleRadius()
+            this.svgParameters.getTransformerCircleRadius()
         );
         arrowPath?.setAttribute('transform', 'matrix(' + matrix + ')');
     }

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -973,15 +973,16 @@ export class NetworkAreaDiagramViewer {
         anchorPoint: Point,
         edgeStart: Point
     ) {
-        const edgeNameElements = DiagramUtils.getEdgeNameElements(edgeNode);
-        const positionElement: SVGGraphicsElement | null = edgeNameElements[0];
+        const positionElement: SVGGraphicsElement | null =
+            edgeNode.querySelector('.nad-edge-label') as SVGGraphicsElement;
         if (positionElement != null) {
             // move edge name position
             positionElement.setAttribute(
                 'transform',
                 'translate(' + DiagramUtils.getFormattedPoint(anchorPoint) + ')'
             );
-            const angleElement: SVGGraphicsElement | null = edgeNameElements[1];
+            const angleElement: SVGGraphicsElement | null =
+                positionElement.querySelector('text') as SVGGraphicsElement;
             if (angleElement != null) {
                 // change edge name angle
                 const edgeNameAngle = DiagramUtils.getEdgeNameAngle(

--- a/src/components/network-area-diagram-viewer/svg-parameters.ts
+++ b/src/components/network-area-diagram-viewer/svg-parameters.ts
@@ -6,19 +6,125 @@
  */
 
 export class SvgParameters {
-    // the SVG parameters values are now hardcoded in this class
-    // the idea is to read them from the metadata included in the SVG
-    voltageLevelCircleRadius = 30.0;
-    interAnnulusSpace = 5.0;
-    transfomerCircleRadius = 20;
-    edgeForkAperture = 60;
-    edgeForkLength = 80.0;
-    arrowShift = 30.0;
-    arrowLabelShift = 19.0;
-    converterStationWidth = 70.0;
-    nodeHollowWidth = 15.0;
-    unknownBusNodeExtraRadius = 10.0;
-    edgeNameDisplayed = true;
+    static readonly VOLTAGE_LEVEL_CIRCLE_RADIUS_PARAMETER_NAME =
+        'voltagelevelcircleradius';
+    static readonly INTER_ANNULUS_SPACE_PARAMETER_NAME = 'interannulusspace';
+    static readonly TRANSFORMER_CIRCLE_RADIUS_PARAMETER_NAME =
+        'transformercircleradius';
+    static readonly EDGES_FORK_APERTURE_PARAMETER_NAME = 'edgesforkaperture';
+    static readonly EDGES_FORK_LENGTH_PARAMETER_NAME = 'edgesforklength';
+    static readonly ARROW_SHIFT_PARAMETER_NAME = 'arrowshift';
+    static readonly ARROW_LABEL_SHIFT_PARAMETER_NAME = 'arrowlabelshift';
+    static readonly CONVERTER_STATION_WIDTH_PARAMETER_NAME =
+        'converterstationwidth';
+    static readonly NODE_HOLLOW_WIDTH_PARAMETER_NAME = 'nodehollowwidth';
+    static readonly UNKNOWN_BUS_NODE_EXTRA_RADIUS_PARAMETER_NAME =
+        'unknownbusnodeextraradius';
+    static readonly EDGE_NAME_DISPLAYED_PARAMETER_NAME = 'edgenamedisplayed';
+
+    static readonly VOLTAGE_LEVEL_CIRCLE_RADIUS_DEFAULT = 30.0;
+    static readonly INTER_ANNULUS_SPACE_DEFAULT = 5.0;
+    static readonly TRANSFORMER_CIRCLE_RADIUS_DEFAULT = 20.0;
+    static readonly EDGES_FORK_APERTURE_DEFAULT = 1.05;
+    static readonly EDGES_FORK_LENGTH_DEFAULT = 80.0;
+    static readonly ARROW_SHIFT_DEFAULT = 30.0;
+    static readonly ARROW_LABEL_SHIFT_DEFAULT = 19.0;
+    static readonly CONVERTER_STATION_WIDTH_DEFAULT = 70.0;
+    static readonly NODE_HOLLOW_WIDTH_DEFAULT = 15.0;
+    static readonly UNKNOWN_BUS_NODE_EXTRA_RADIUS_DEFAULT = 10.0;
+    static readonly EDGE_NAME_DISPLAYED_DEFAULT = true;
+
+    voltageLevelCircleRadius: number;
+    interAnnulusSpace: number;
+    transformerCircleRadius: number;
+    edgesForkAperture: number;
+    edgesForkLength: number;
+    arrowShift: number;
+    arrowLabelShift: number;
+    converterStationWidth: number;
+    nodeHollowWidth: number;
+    unknownBusNodeExtraRadius: number;
+    edgeNameDisplayed: boolean;
+
+    constructor(svgParametersElement: SVGGraphicsElement | null) {
+        this.voltageLevelCircleRadius = this.getNumberParameter(
+            svgParametersElement,
+            SvgParameters.VOLTAGE_LEVEL_CIRCLE_RADIUS_PARAMETER_NAME,
+            SvgParameters.VOLTAGE_LEVEL_CIRCLE_RADIUS_DEFAULT
+        );
+        this.interAnnulusSpace = this.getNumberParameter(
+            svgParametersElement,
+            SvgParameters.INTER_ANNULUS_SPACE_PARAMETER_NAME,
+            SvgParameters.INTER_ANNULUS_SPACE_DEFAULT
+        );
+        this.transformerCircleRadius = this.getNumberParameter(
+            svgParametersElement,
+            SvgParameters.TRANSFORMER_CIRCLE_RADIUS_PARAMETER_NAME,
+            SvgParameters.TRANSFORMER_CIRCLE_RADIUS_DEFAULT
+        );
+        this.edgesForkAperture = this.getNumberParameter(
+            svgParametersElement,
+            SvgParameters.EDGES_FORK_APERTURE_PARAMETER_NAME,
+            SvgParameters.EDGES_FORK_APERTURE_DEFAULT
+        );
+        this.edgesForkLength = this.getNumberParameter(
+            svgParametersElement,
+            SvgParameters.EDGES_FORK_LENGTH_PARAMETER_NAME,
+            SvgParameters.EDGES_FORK_LENGTH_DEFAULT
+        );
+        this.arrowShift = this.getNumberParameter(
+            svgParametersElement,
+            SvgParameters.ARROW_SHIFT_PARAMETER_NAME,
+            SvgParameters.ARROW_SHIFT_DEFAULT
+        );
+        this.arrowLabelShift = this.getNumberParameter(
+            svgParametersElement,
+            SvgParameters.ARROW_LABEL_SHIFT_PARAMETER_NAME,
+            SvgParameters.ARROW_LABEL_SHIFT_DEFAULT
+        );
+        this.converterStationWidth = this.getNumberParameter(
+            svgParametersElement,
+            SvgParameters.CONVERTER_STATION_WIDTH_PARAMETER_NAME,
+            SvgParameters.CONVERTER_STATION_WIDTH_DEFAULT
+        );
+        this.nodeHollowWidth = this.getNumberParameter(
+            svgParametersElement,
+            SvgParameters.NODE_HOLLOW_WIDTH_PARAMETER_NAME,
+            SvgParameters.NODE_HOLLOW_WIDTH_DEFAULT
+        );
+        this.unknownBusNodeExtraRadius = this.getNumberParameter(
+            svgParametersElement,
+            SvgParameters.UNKNOWN_BUS_NODE_EXTRA_RADIUS_PARAMETER_NAME,
+            SvgParameters.UNKNOWN_BUS_NODE_EXTRA_RADIUS_DEFAULT
+        );
+        this.edgeNameDisplayed = this.getBooleanParameter(
+            svgParametersElement,
+            SvgParameters.EDGE_NAME_DISPLAYED_PARAMETER_NAME,
+            SvgParameters.EDGE_NAME_DISPLAYED_DEFAULT
+        );
+    }
+
+    private getNumberParameter(
+        svgParametersElement: SVGGraphicsElement | null,
+        parameterName: string,
+        parameterDefault: number
+    ): number {
+        const parameter = svgParametersElement?.getAttribute(parameterName);
+        return parameter !== undefined && parameter !== null
+            ? +parameter
+            : parameterDefault;
+    }
+
+    private getBooleanParameter(
+        svgParametersElement: SVGGraphicsElement | null,
+        parameterName: string,
+        parameterDefault: boolean
+    ): boolean {
+        const parameter = svgParametersElement?.getAttribute(parameterName);
+        return parameter !== undefined && parameter !== null
+            ? parameter === 'true'
+            : parameterDefault;
+    }
 
     public getVoltageLevelCircleRadius(): number {
         return this.voltageLevelCircleRadius;
@@ -28,16 +134,16 @@ export class SvgParameters {
         return this.interAnnulusSpace;
     }
 
-    public getTransfomerCircleRadius(): number {
-        return this.transfomerCircleRadius;
+    public getTransformerCircleRadius(): number {
+        return this.transformerCircleRadius;
     }
 
-    public getEdgeForkAperture(): number {
-        return this.edgeForkAperture;
+    public getEdgesForkAperture(): number {
+        return this.edgesForkAperture;
     }
 
-    public getEdgeForkLength(): number {
-        return this.edgeForkLength;
+    public getEdgesForkLength(): number {
+        return this.edgesForkLength;
     }
 
     public getArrowShift(): number {

--- a/src/components/network-area-diagram-viewer/svg-parameters.ts
+++ b/src/components/network-area-diagram-viewer/svg-parameters.ts
@@ -18,6 +18,7 @@ export class SvgParameters {
     converterStationWidth = 70.0;
     nodeHollowWidth = 15.0;
     unknownBusNodeExtraRadius = 10.0;
+    edgeNameDisplayed = true;
 
     public getVoltageLevelCircleRadius(): number {
         return this.voltageLevelCircleRadius;
@@ -57,5 +58,9 @@ export class SvgParameters {
 
     public getUnknownBusNodeExtraRadius(): number {
         return this.unknownBusNodeExtraRadius;
+    }
+
+    public getEdgeNameDisplayed(): boolean {
+        return this.edgeNameDisplayed;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
feature


**What is the current behavior?**
The SVG parameters used for handling the nodes moving are hardcoded in a class


**What is the new behavior (if this is a feature change)?**
The SVG parameters used for handling the nodes moving are read from the SVG metadata


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No