### PR TITLE
Add GitHub action to automate release publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Publish
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -28,16 +28,12 @@ you need to follow the steps below:
 -   Update to the new version in [package.json](https://github.com/powsybl/powsybl-diagram-viewer/blob/main/package.json) (example `0.6.0`)
 -   Update the package-lock.json: `npm install`
 -   Commit the package.json and package-lock.json files, push to a branch, make a PR, have it reviewed and merged to main.
--   Pull and checkout main on your last commit.
--   [Tag your last commit](https://semver.org/) : `git tag <tag>` (example: `git tag v0.6.0`)
--   Push tag : `git push origin <tag>`  
----
--   (Optional) Checkout the tag in a fresh repo copy : `cd $(mktemp -d) && git clone https://github.com/powsybl/powsybl-diagram-viewer.git` then `cd powsybl-diagram-viewer && git checkout <tag>`
--   (Optional) [Test your package](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages#testing-your-package): `npm install`  
----
--   Build the package - npm will publish the README.md, the package.json and the dist directory you just generate : `npm run build`
--   [Login on the command line to the npm registry](https://docs.npmjs.com/logging-in-to-an-npm-enterprise-registry-from-the-command-line): `npm login`
--   [Publish the package](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages#publishing-scoped-public-packages): `npm publish`
+-   [Make a release](https://github.com/powsybl/powsybl-diagram-viewer/releases/new) on GitHub by creating a new tag on the last commit. On the release creation page:
+  - In "Choose a tag": type the tag you want to create (ex.: v0.6.0) and select "create new tag"
+  - In "Target": click on "recent commit" tab and select your release commit
+  - Click on "Generate release note"
+  - Click on "Publish release"
+-   It will trigger a job that will publish the release on NPM
 
 Notes :
 * Check [license-checker-config.json](license-checker-config.json) for license white list and exclusion.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?**
Add a GitHub action to automate publishing on npmjs when a developer releases the repository on GitHub. 


**What is the current behavior?**
Only developers with publishing rights on npmjs could publish a release.


**What is the new behavior (if this is a feature change)?**
Through the github action, the npmjs publication is automated.
