### PR TITLE
Allow to select nodes in network area diagram viewer

### DIFF
--- a/demo/src/diagram-viewers/add-diagrams.ts
+++ b/demo/src/diagram-viewers/add-diagrams.ts
@@ -341,21 +341,7 @@ const handleNodeMove: OnMoveNodeCallbackType = (
     console.log(msg);
 };
 
-const handleNodeSelect: OnSelectNodeCallbackType = (
-    equipmentId,
-    nodeId,
-    x,
-    y
-) => {
-    const msg =
-        'Node ' +
-        nodeId +
-        ' equipment ' +
-        equipmentId +
-        ' position [' +
-        x +
-        ', ' +
-        y +
-        '] selected';
+const handleNodeSelect: OnSelectNodeCallbackType = (equipmentId, nodeId) => {
+    const msg = 'Node ' + nodeId + ' equipment ' + equipmentId + ' selected';
     console.log(msg);
 };

--- a/demo/src/diagram-viewers/add-diagrams.ts
+++ b/demo/src/diagram-viewers/add-diagrams.ts
@@ -24,6 +24,8 @@ import {
     OnBusCallbackType,
     OnFeederCallbackType,
     OnNextVoltageCallbackType,
+    OnMoveNodeCallbackType,
+    OnSelectNodeCallbackType,
 } from '../../../src';
 
 export const addNadToDemo = () => {
@@ -38,6 +40,7 @@ export const addNadToDemo = () => {
                 1000,
                 1200,
                 handleNodeMove,
+                handleNodeSelect,
                 true
             );
 
@@ -58,6 +61,7 @@ export const addNadToDemo = () => {
                 1000,
                 1200,
                 handleNodeMove,
+                handleNodeSelect,
                 false
             );
 
@@ -78,6 +82,7 @@ export const addNadToDemo = () => {
                 1000,
                 1200,
                 handleNodeMove,
+                handleNodeSelect,
                 true
             );
 
@@ -100,6 +105,7 @@ export const addNadToDemo = () => {
                 1000,
                 1200,
                 handleNodeMove,
+                handleNodeSelect,
                 true
             );
 
@@ -120,6 +126,7 @@ export const addNadToDemo = () => {
                 1000,
                 1200,
                 handleNodeMove,
+                handleNodeSelect,
                 true
             );
 
@@ -140,6 +147,7 @@ export const addNadToDemo = () => {
                 1000,
                 1200,
                 handleNodeMove,
+                handleNodeSelect,
                 true
             );
 
@@ -160,6 +168,7 @@ export const addNadToDemo = () => {
                 1000,
                 1200,
                 handleNodeMove,
+                handleNodeSelect,
                 true
             );
 
@@ -307,7 +316,14 @@ const handleTogglePopover: HandleTogglePopoverType = (
     }
 };
 
-const handleNodeMove = (equipmentId, nodeId, x, y, xOrig, yOrig) => {
+const handleNodeMove: OnMoveNodeCallbackType = (
+    equipmentId,
+    nodeId,
+    x,
+    y,
+    xOrig,
+    yOrig
+) => {
     const msg =
         'Node ' +
         nodeId +
@@ -322,5 +338,24 @@ const handleNodeMove = (equipmentId, nodeId, x, y, xOrig, yOrig) => {
         ', ' +
         y +
         ']';
+    console.log(msg);
+};
+
+const handleNodeSelect: OnSelectNodeCallbackType = (
+    equipmentId,
+    nodeId,
+    x,
+    y
+) => {
+    const msg =
+        'Node ' +
+        nodeId +
+        ' equipment ' +
+        equipmentId +
+        ' position [' +
+        x +
+        ', ' +
+        y +
+        '] selected';
     console.log(msg);
 };

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.test.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.test.ts
@@ -20,6 +20,7 @@ describe('Test network-area-diagram-viewer', () => {
             0,
             0,
             null,
+            null,
             false
         );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,10 @@
  */
 
 export { NetworkAreaDiagramViewer } from './components/network-area-diagram-viewer/network-area-diagram-viewer';
+export type {
+    OnMoveNodeCallbackType,
+    OnSelectNodeCallbackType,
+} from './components/network-area-diagram-viewer/network-area-diagram-viewer';
 export { SingleLineDiagramViewer } from './components/single-line-diagram-viewer/single-line-diagram-viewer';
 export type {
     HandleTogglePopoverType,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
feature


**What is the current behavior?**
In the network area diagram viewer it is not possible to only select a node: if the node moving is enabled, when clicking on a node, the node is moved. 


**What is the new behavior (if this is a feature change)?**
In the network area diagram viewer it is possible to select a node: when clicking on a node, if the SHIFT key is pressed the node is selected, if not the node is moved. A callback allows to have information about the selected node.


**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [X] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
The constructor of the NetworkAreaDiagramViewer has a new additional parameter: the callback.
An example of callback is provided in the demo/src/diagram-viewers/add-diagrams.ts file