### PR TITLE
Read layout parameters from metadata in network area diagram viewer

### DIFF
--- a/demo/src/diagram-viewers/data/nad-eurostag-tutorial-example1.svg
+++ b/demo/src/diagram-viewers/data/nad-eurostag-tutorial-example1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="-652.59 -489.01 1383.49 747.62" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="-652.59 -514.01 1383.49 772.62" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
@@ -136,6 +136,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 <nad:textNode svgId="6-textnode" equipmentId="VLLOAD" vlNode="6" shiftX="100.00" shiftY="-40.00" connectionShiftX="100.00" connectionShiftY="-15.00"/>
             </nad:textNodes>
             <nad:svgParameters insertNameDesc="false" svgWidthAndHeightAdded="false" cssLocation="INSERTED_IN_SVG" sizeConstraint="FIXED_SCALE" fixedWidth="-1" fixedHeight="-1" fixedScale="0.2" arrowShift="30.00" arrowLabelShift="19.00" converterStationWidth="70.00" voltageLevelCircleRadius="30.00" fictitiousVoltageLevelCircleRadius="15.00" transformerCircleRadius="20.00" nodeHollowWidth="15.00" edgesForkLength="80.00" edgesForkAperture="1.05" edgeStartShift="0.00" unknownBusNodeExtraRadius="10.00" loopDistance="120.00" loopEdgesAperture="1.05" loopControlDistance="40.00" edgeInfoAlongEdge="true" edgeNameDisplayed="true" interAnnulusSpace="5.00" svgPrefix="" idDisplayed="false" substationDescriptionDisplayed="false" arrowHeight="10.00" busLegend="true" voltageLevelDetails="false" languageTag="en" voltageValuePrecision="1" powerValuePrecision="0" angleValuePrecision="1" currentValuePrecision="0" edgeInfoDisplayed="ACTIVE_POWER" pstArrowHeadSize="8.00" undefinedValueSymbol=""/>
+            <nad:layoutParameters textNodesForceLayout="false" springRepulsionFactorForceLayout="0.00" textNodeFixedShiftX="100.00" textNodeFixedShiftY="-40.00" maxSteps="1000" textNodeEdgeConnectionYShift="25.00"/>
         </nad:nad>
     </metadata>
     <g class="nad-vl-nodes">

--- a/demo/src/diagram-viewers/data/nad-four-substations.svg
+++ b/demo/src/diagram-viewers/data/nad-four-substations.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="-420.40 -730.14 1217.75 1232.45" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="-420.40 -755.14 1217.75 1257.45" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
@@ -140,6 +140,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 <nad:textNode svgId="8-textnode" equipmentId="S4VL1" vlNode="8" shiftX="100.00" shiftY="-40.00" connectionShiftX="100.00" connectionShiftY="-15.00"/>
             </nad:textNodes>
             <nad:svgParameters insertNameDesc="false" svgWidthAndHeightAdded="false" cssLocation="INSERTED_IN_SVG" sizeConstraint="FIXED_SCALE" fixedWidth="-1" fixedHeight="-1" fixedScale="0.2" arrowShift="30.00" arrowLabelShift="19.00" converterStationWidth="70.00" voltageLevelCircleRadius="30.00" fictitiousVoltageLevelCircleRadius="15.00" transformerCircleRadius="20.00" nodeHollowWidth="15.00" edgesForkLength="80.00" edgesForkAperture="1.05" edgeStartShift="0.00" unknownBusNodeExtraRadius="10.00" loopDistance="120.00" loopEdgesAperture="1.05" loopControlDistance="40.00" edgeInfoAlongEdge="true" edgeNameDisplayed="false" interAnnulusSpace="5.00" svgPrefix="" idDisplayed="false" substationDescriptionDisplayed="false" arrowHeight="10.00" busLegend="true" voltageLevelDetails="false" languageTag="en" voltageValuePrecision="1" powerValuePrecision="0" angleValuePrecision="1" currentValuePrecision="0" edgeInfoDisplayed="ACTIVE_POWER" pstArrowHeadSize="8.00" undefinedValueSymbol=""/>
+            <nad:layoutParameters textNodesForceLayout="false" springRepulsionFactorForceLayout="0.00" textNodeFixedShiftX="100.00" textNodeFixedShiftY="-40.00" maxSteps="1000" textNodeEdgeConnectionYShift="25.00"/>
         </nad:nad>
     </metadata>
     <g class="nad-vl-nodes">

--- a/demo/src/diagram-viewers/data/nad-ieee14cdf-solved.svg
+++ b/demo/src/diagram-viewers/data/nad-ieee14cdf-solved.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="-773.57 -884.23 1767.75 1503.47" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="-773.57 -909.23 1767.75 1528.47" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
@@ -176,6 +176,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 <nad:textNode svgId="23-textnode" equipmentId="VL8" vlNode="23" shiftX="100.00" shiftY="-40.00" connectionShiftX="100.00" connectionShiftY="-15.00"/>
             </nad:textNodes>
             <nad:svgParameters insertNameDesc="false" svgWidthAndHeightAdded="false" cssLocation="INSERTED_IN_SVG" sizeConstraint="FIXED_SCALE" fixedWidth="-1" fixedHeight="-1" fixedScale="0.2" arrowShift="30.00" arrowLabelShift="19.00" converterStationWidth="70.00" voltageLevelCircleRadius="30.00" fictitiousVoltageLevelCircleRadius="15.00" transformerCircleRadius="20.00" nodeHollowWidth="15.00" edgesForkLength="80.00" edgesForkAperture="1.05" edgeStartShift="0.00" unknownBusNodeExtraRadius="10.00" loopDistance="120.00" loopEdgesAperture="1.05" loopControlDistance="40.00" edgeInfoAlongEdge="true" edgeNameDisplayed="false" interAnnulusSpace="5.00" svgPrefix="" idDisplayed="false" substationDescriptionDisplayed="false" arrowHeight="10.00" busLegend="true" voltageLevelDetails="false" languageTag="en" voltageValuePrecision="1" powerValuePrecision="0" angleValuePrecision="1" currentValuePrecision="0" edgeInfoDisplayed="ACTIVE_POWER" pstArrowHeadSize="8.00" undefinedValueSymbol=""/>
+            <nad:layoutParameters textNodesForceLayout="false" springRepulsionFactorForceLayout="0.00" textNodeFixedShiftX="100.00" textNodeFixedShiftY="-40.00" maxSteps="1000" textNodeEdgeConnectionYShift="25.00"/>
         </nad:nad>
     </metadata>
     <g class="nad-vl-nodes">

--- a/demo/src/diagram-viewers/data/nad-ieee300cdf-VL9006.svg
+++ b/demo/src/diagram-viewers/data/nad-ieee300cdf-VL9006.svg
@@ -207,6 +207,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 <nad:textNode svgId="12-textnode" equipmentId="VL9121" vlNode="12" shiftX="100.00" shiftY="-40.00" connectionShiftX="100.00" connectionShiftY="-15.00"/>
             </nad:textNodes>
             <nad:svgParameters insertNameDesc="false" svgWidthAndHeightAdded="false" cssLocation="INSERTED_IN_SVG" sizeConstraint="FIXED_SCALE" fixedWidth="-1" fixedHeight="-1" fixedScale="0.2" arrowShift="30.00" arrowLabelShift="19.00" converterStationWidth="70.00" voltageLevelCircleRadius="30.00" fictitiousVoltageLevelCircleRadius="15.00" transformerCircleRadius="20.00" nodeHollowWidth="15.00" edgesForkLength="80.00" edgesForkAperture="1.05" edgeStartShift="0.00" unknownBusNodeExtraRadius="10.00" loopDistance="120.00" loopEdgesAperture="1.05" loopControlDistance="40.00" edgeInfoAlongEdge="true" edgeNameDisplayed="false" interAnnulusSpace="5.00" svgPrefix="" idDisplayed="false" substationDescriptionDisplayed="false" arrowHeight="10.00" busLegend="true" voltageLevelDetails="false" languageTag="en" voltageValuePrecision="1" powerValuePrecision="0" angleValuePrecision="1" currentValuePrecision="0" edgeInfoDisplayed="ACTIVE_POWER" pstArrowHeadSize="8.00" undefinedValueSymbol=""/>
+            <nad:layoutParameters textNodesForceLayout="false" springRepulsionFactorForceLayout="0.00" textNodeFixedShiftX="100.00" textNodeFixedShiftY="-40.00" maxSteps="1000" textNodeEdgeConnectionYShift="25.00"/>
         </nad:nad>
     </metadata>
     <g class="nad-vl-nodes">

--- a/demo/src/diagram-viewers/data/nad-ieee9-zeroimpedance-cdf.svg
+++ b/demo/src/diagram-viewers/data/nad-ieee9-zeroimpedance-cdf.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="-483.06 -586.47 1096.85 1076.86" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="-483.06 -611.47 1096.85 1101.86" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
@@ -148,6 +148,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 <nad:textNode svgId="12-textnode" equipmentId="VL6" vlNode="12" shiftX="100.00" shiftY="-40.00" connectionShiftX="100.00" connectionShiftY="-15.00"/>
             </nad:textNodes>
             <nad:svgParameters insertNameDesc="false" svgWidthAndHeightAdded="false" cssLocation="INSERTED_IN_SVG" sizeConstraint="FIXED_SCALE" fixedWidth="-1" fixedHeight="-1" fixedScale="0.2" arrowShift="30.00" arrowLabelShift="19.00" converterStationWidth="70.00" voltageLevelCircleRadius="30.00" fictitiousVoltageLevelCircleRadius="15.00" transformerCircleRadius="20.00" nodeHollowWidth="15.00" edgesForkLength="80.00" edgesForkAperture="1.05" edgeStartShift="0.00" unknownBusNodeExtraRadius="10.00" loopDistance="120.00" loopEdgesAperture="1.05" loopControlDistance="40.00" edgeInfoAlongEdge="true" edgeNameDisplayed="false" interAnnulusSpace="5.00" svgPrefix="" idDisplayed="false" substationDescriptionDisplayed="false" arrowHeight="10.00" busLegend="true" voltageLevelDetails="false" languageTag="en" voltageValuePrecision="1" powerValuePrecision="0" angleValuePrecision="1" currentValuePrecision="0" edgeInfoDisplayed="ACTIVE_POWER" pstArrowHeadSize="8.00" undefinedValueSymbol=""/>
+            <nad:layoutParameters textNodesForceLayout="false" springRepulsionFactorForceLayout="0.00" textNodeFixedShiftX="100.00" textNodeFixedShiftY="-40.00" maxSteps="1000" textNodeEdgeConnectionYShift="25.00"/>
         </nad:nad>
     </metadata>
     <g class="nad-vl-nodes">

--- a/demo/src/diagram-viewers/data/nad-scada.svg
+++ b/demo/src/diagram-viewers/data/nad-scada.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="-512.98 -692.87 1172.34 1295.65" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="-512.98 -717.87 1172.34 1320.65" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
@@ -138,6 +138,7 @@ path.nad-arrow-in:not(.nad-state-in .nad-arrow-in) {visibility: hidden}
                 <nad:textNode svgId="4-textnode" equipmentId="vl3" vlNode="4" shiftX="100.00" shiftY="-40.00" connectionShiftX="100.00" connectionShiftY="-15.00"/>
             </nad:textNodes>
             <nad:svgParameters insertNameDesc="false" svgWidthAndHeightAdded="false" cssLocation="INSERTED_IN_SVG" sizeConstraint="FIXED_SCALE" fixedWidth="-1" fixedHeight="-1" fixedScale="0.2" arrowShift="30.00" arrowLabelShift="19.00" converterStationWidth="70.00" voltageLevelCircleRadius="30.00" fictitiousVoltageLevelCircleRadius="15.00" transformerCircleRadius="20.00" nodeHollowWidth="15.00" edgesForkLength="80.00" edgesForkAperture="1.05" edgeStartShift="0.00" unknownBusNodeExtraRadius="10.00" loopDistance="120.00" loopEdgesAperture="1.05" loopControlDistance="40.00" edgeInfoAlongEdge="true" edgeNameDisplayed="true" interAnnulusSpace="5.00" svgPrefix="" idDisplayed="false" substationDescriptionDisplayed="false" arrowHeight="10.00" busLegend="true" voltageLevelDetails="false" languageTag="en" voltageValuePrecision="1" powerValuePrecision="0" angleValuePrecision="1" currentValuePrecision="0" edgeInfoDisplayed="ACTIVE_POWER" pstArrowHeadSize="8.00" undefinedValueSymbol=""/>
+            <nad:layoutParameters textNodesForceLayout="false" springRepulsionFactorForceLayout="0.00" textNodeFixedShiftX="100.00" textNodeFixedShiftY="-40.00" maxSteps="1000" textNodeEdgeConnectionYShift="25.00"/>
         </nad:nad>
     </metadata>
     <g class="nad-vl-nodes">

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -484,3 +484,23 @@ export function getTextNodeMoves(
         { xOrig: connXOrig, yOrig: connYOrig, xNew: connXNew, yNew: connYNew },
     ];
 }
+
+// get number parameter from metadata element
+export function getNumberParameter(
+    parametersMetadataElement: SVGGraphicsElement | null,
+    parameterName: string,
+    parameterDefault: number
+): number {
+    const parameter = parametersMetadataElement?.getAttribute(parameterName);
+    return parameter !== undefined && parameter !== null ? +parameter : parameterDefault;
+}
+
+// get boolean parameter from metadata element
+export function getBooleanParameter(
+    parametersMetadataElement: SVGGraphicsElement | null,
+    parameterName: string,
+    parameterDefault: boolean
+): boolean {
+    const parameter = parametersMetadataElement?.getAttribute(parameterName);
+    return parameter !== undefined && parameter !== null ? parameter === 'true' : parameterDefault;
+}

--- a/src/components/network-area-diagram-viewer/layout-parameters.ts
+++ b/src/components/network-area-diagram-viewer/layout-parameters.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { getNumberParameter } from './diagram-utils';
+
+export class LayoutParameters {
+    static readonly TEXT_NODE_EDGE_CONNECTION_Y_SHIFT_PARAMETER_NAME = 'textnodeedgeconnectionyshift';
+
+    static readonly TEXT_NODE_EDGE_CONNECTION_Y_SHIFT_DEFAULT = 25.0;
+
+    textNodeEdgeConnectionYShift: number;
+
+    constructor(layoutParametersElement: SVGGraphicsElement | null) {
+        this.textNodeEdgeConnectionYShift = getNumberParameter(
+            layoutParametersElement,
+            LayoutParameters.TEXT_NODE_EDGE_CONNECTION_Y_SHIFT_PARAMETER_NAME,
+            LayoutParameters.TEXT_NODE_EDGE_CONNECTION_Y_SHIFT_DEFAULT
+        );
+    }
+
+    public getTextNodeEdgeConnectionYShift(): number {
+        return this.textNodeEdgeConnectionYShift;
+    }
+}

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -9,6 +9,7 @@ import { Point, SVG, ViewBoxLike, Svg } from '@svgdotjs/svg.js';
 import '@svgdotjs/svg.panzoom.js';
 import * as DiagramUtils from './diagram-utils';
 import { SvgParameters } from './svg-parameters';
+import { LayoutParameters } from './layout-parameters';
 
 type DIMENSIONS = { width: number; height: number; viewbox: VIEWBOX };
 type VIEWBOX = { x: number; y: number; width: number; height: number };
@@ -52,6 +53,7 @@ export class NetworkAreaDiagramViewer {
     ctm: DOMMatrix | null | undefined = null;
     initialPosition: Point = new Point(0, 0);
     svgParameters: SvgParameters;
+    layoutParameters: LayoutParameters;
     edgeAngles: Map<string, number> = new Map<string, number>();
     textNodeSelected: boolean = false;
     endTextEdge: Point = new Point(0, 0);
@@ -80,6 +82,7 @@ export class NetworkAreaDiagramViewer {
         this.originalHeight = 0;
         this.init(minWidth, minHeight, maxWidth, maxHeight, enableNodeMoving);
         this.svgParameters = this.getSvgParameters();
+        this.layoutParameters = this.getLayoutParameters();
         this.onMoveNodeCallback = onMoveNodeCallback;
         this.onMoveTextNodeCallback = onMoveTextNodeCallback;
         this.onSelectNodeCallback = onSelectNodeCallback;
@@ -262,6 +265,12 @@ export class NetworkAreaDiagramViewer {
         return new SvgParameters(svgParametersElement);
     }
 
+    private getLayoutParameters(): LayoutParameters {
+        const layoutParametersElement: SVGGraphicsElement | null =
+            this.container.querySelector('nad\\:layoutparameters');
+        return new LayoutParameters(layoutParametersElement);
+    }
+
     private startDrag(event: Event) {
         const draggableElem = DiagramUtils.getDraggableFrom(event.target as SVGElement);
         if (!draggableElem) {
@@ -429,7 +438,7 @@ export class NetworkAreaDiagramViewer {
             this.endTextEdge = DiagramUtils.getTextEdgeEnd(
                 textNodePosition,
                 vlNodePosition,
-                this.svgParameters.getDetailedTextNodeYShift(),
+                this.layoutParameters.getTextNodeEdgeConnectionYShift(),
                 textHeight,
                 textWidth
             );

--- a/src/components/network-area-diagram-viewer/svg-parameters.ts
+++ b/src/components/network-area-diagram-viewer/svg-parameters.ts
@@ -5,6 +5,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { getNumberParameter, getBooleanParameter } from './diagram-utils';
+
 export class SvgParameters {
     static readonly VOLTAGE_LEVEL_CIRCLE_RADIUS_PARAMETER_NAME = 'voltagelevelcircleradius';
     static readonly INTER_ANNULUS_SPACE_PARAMETER_NAME = 'interannulusspace';
@@ -17,7 +19,6 @@ export class SvgParameters {
     static readonly NODE_HOLLOW_WIDTH_PARAMETER_NAME = 'nodehollowwidth';
     static readonly UNKNOWN_BUS_NODE_EXTRA_RADIUS_PARAMETER_NAME = 'unknownbusnodeextraradius';
     static readonly EDGE_NAME_DISPLAYED_PARAMETER_NAME = 'edgenamedisplayed';
-    static readonly DETAILED_TEXT_NODE_Y_SHIFT_PARAMETER_NAME = 'detailedtextnodeyshift';
 
     static readonly VOLTAGE_LEVEL_CIRCLE_RADIUS_DEFAULT = 30.0;
     static readonly INTER_ANNULUS_SPACE_DEFAULT = 5.0;
@@ -30,7 +31,6 @@ export class SvgParameters {
     static readonly NODE_HOLLOW_WIDTH_DEFAULT = 15.0;
     static readonly UNKNOWN_BUS_NODE_EXTRA_RADIUS_DEFAULT = 10.0;
     static readonly EDGE_NAME_DISPLAYED_DEFAULT = true;
-    static readonly DETAILED_TEXT_NODE_Y_SHIFT_DEFAULT = 25.0;
 
     voltageLevelCircleRadius: number;
     interAnnulusSpace: number;
@@ -43,85 +43,63 @@ export class SvgParameters {
     nodeHollowWidth: number;
     unknownBusNodeExtraRadius: number;
     edgeNameDisplayed: boolean;
-    detailedTextNodeYShift: number;
 
     constructor(svgParametersElement: SVGGraphicsElement | null) {
-        this.voltageLevelCircleRadius = this.getNumberParameter(
+        this.voltageLevelCircleRadius = getNumberParameter(
             svgParametersElement,
             SvgParameters.VOLTAGE_LEVEL_CIRCLE_RADIUS_PARAMETER_NAME,
             SvgParameters.VOLTAGE_LEVEL_CIRCLE_RADIUS_DEFAULT
         );
-        this.interAnnulusSpace = this.getNumberParameter(
+        this.interAnnulusSpace = getNumberParameter(
             svgParametersElement,
             SvgParameters.INTER_ANNULUS_SPACE_PARAMETER_NAME,
             SvgParameters.INTER_ANNULUS_SPACE_DEFAULT
         );
-        this.transformerCircleRadius = this.getNumberParameter(
+        this.transformerCircleRadius = getNumberParameter(
             svgParametersElement,
             SvgParameters.TRANSFORMER_CIRCLE_RADIUS_PARAMETER_NAME,
             SvgParameters.TRANSFORMER_CIRCLE_RADIUS_DEFAULT
         );
-        this.edgesForkAperture = this.getNumberParameter(
+        this.edgesForkAperture = getNumberParameter(
             svgParametersElement,
             SvgParameters.EDGES_FORK_APERTURE_PARAMETER_NAME,
             SvgParameters.EDGES_FORK_APERTURE_DEFAULT
         );
-        this.edgesForkLength = this.getNumberParameter(
+        this.edgesForkLength = getNumberParameter(
             svgParametersElement,
             SvgParameters.EDGES_FORK_LENGTH_PARAMETER_NAME,
             SvgParameters.EDGES_FORK_LENGTH_DEFAULT
         );
-        this.arrowShift = this.getNumberParameter(
+        this.arrowShift = getNumberParameter(
             svgParametersElement,
             SvgParameters.ARROW_SHIFT_PARAMETER_NAME,
             SvgParameters.ARROW_SHIFT_DEFAULT
         );
-        this.arrowLabelShift = this.getNumberParameter(
+        this.arrowLabelShift = getNumberParameter(
             svgParametersElement,
             SvgParameters.ARROW_LABEL_SHIFT_PARAMETER_NAME,
             SvgParameters.ARROW_LABEL_SHIFT_DEFAULT
         );
-        this.converterStationWidth = this.getNumberParameter(
+        this.converterStationWidth = getNumberParameter(
             svgParametersElement,
             SvgParameters.CONVERTER_STATION_WIDTH_PARAMETER_NAME,
             SvgParameters.CONVERTER_STATION_WIDTH_DEFAULT
         );
-        this.nodeHollowWidth = this.getNumberParameter(
+        this.nodeHollowWidth = getNumberParameter(
             svgParametersElement,
             SvgParameters.NODE_HOLLOW_WIDTH_PARAMETER_NAME,
             SvgParameters.NODE_HOLLOW_WIDTH_DEFAULT
         );
-        this.unknownBusNodeExtraRadius = this.getNumberParameter(
+        this.unknownBusNodeExtraRadius = getNumberParameter(
             svgParametersElement,
             SvgParameters.UNKNOWN_BUS_NODE_EXTRA_RADIUS_PARAMETER_NAME,
             SvgParameters.UNKNOWN_BUS_NODE_EXTRA_RADIUS_DEFAULT
         );
-        this.edgeNameDisplayed = this.getBooleanParameter(
+        this.edgeNameDisplayed = getBooleanParameter(
             svgParametersElement,
             SvgParameters.EDGE_NAME_DISPLAYED_PARAMETER_NAME,
             SvgParameters.EDGE_NAME_DISPLAYED_DEFAULT
         );
-        // parameter moved from svg parameters to layout parameters
-        // value hardcoded, waiting for the layout parameter in metadata
-        this.detailedTextNodeYShift = SvgParameters.DETAILED_TEXT_NODE_Y_SHIFT_DEFAULT;
-    }
-
-    private getNumberParameter(
-        svgParametersElement: SVGGraphicsElement | null,
-        parameterName: string,
-        parameterDefault: number
-    ): number {
-        const parameter = svgParametersElement?.getAttribute(parameterName);
-        return parameter !== undefined && parameter !== null ? +parameter : parameterDefault;
-    }
-
-    private getBooleanParameter(
-        svgParametersElement: SVGGraphicsElement | null,
-        parameterName: string,
-        parameterDefault: boolean
-    ): boolean {
-        const parameter = svgParametersElement?.getAttribute(parameterName);
-        return parameter !== undefined && parameter !== null ? parameter === 'true' : parameterDefault;
     }
 
     public getVoltageLevelCircleRadius(): number {
@@ -166,9 +144,5 @@ export class SvgParameters {
 
     public getEdgeNameDisplayed(): boolean {
         return this.edgeNameDisplayed;
-    }
-
-    public getDetailedTextNodeYShift(): number {
-        return this.detailedTextNodeYShift;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
feature


**What is the current behavior?**
the value of the detailedTextNodeYShift parameter, used for handling the text nodes moving and no more included in the metadata of the SVG, is hardcoded in the viewer


**What is the new behavior (if this is a feature change)?**
The layout parameters, specifically the textNodeEdgeConnectionYShift parameter used for handling the text nodes moving, are read from the SVG metadata


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No