### PR TITLE
nad-viewer: fix calling move callback, fix boundary node moving

### DIFF
--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -1191,7 +1191,7 @@ export class NetworkAreaDiagramViewer {
     private updateNodeMetadataCallCallback(mousePosition: Point, callMoveNodeCallback: boolean) {
         // get moved node from metadata
         const node: NodeMetadata | undefined = this.diagramMetadata?.nodes.find(
-            (node) => node.svgId == this.selectedElement?.id
+            (node) => node.svgId == this.draggedElement?.id
         );
         if (node != null) {
             const nodeMove = DiagramUtils.getNodeMove(node, mousePosition);

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -765,8 +765,8 @@ export class NetworkAreaDiagramViewer {
         // if dangling line edge -> redraw boundary node
         if (edgeType == DiagramUtils.EdgeType.DANGLING_LINE) {
             this.redrawBoundaryNode(edgeNodes[1], DiagramUtils.getAngle(edgeStart2, edgeMiddle), nodeRadius2[1]);
-            if (this.selectedElement?.id == edgeNodes[1]?.id) {
-                // if boudary node moved -> redraw other voltage level node
+            if (this.draggedElement?.id == edgeNodes[1]?.id) {
+                // if boundary node moved -> redraw other voltage level node
                 this.redrawOtherVoltageLevelNode(edgeNodes[0], [edge]);
             }
         } else {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
In network area diagram viewer,
- when moving a node, the node metadata is not updated and the move node callback is not called
- when moving a boundary node, the other node is not redrawn



**What is the new behavior (if this is a feature change)?**
- when moving a node, the node metadata is updated and the move node callback is called
- when moving a boundary node, the other node is redrawn 


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No